### PR TITLE
Make whitelist/blacklists mutually exclusive

### DIFF
--- a/src/detector.rs
+++ b/src/detector.rs
@@ -2,7 +2,6 @@ use lang::Lang;
 use script::Script;
 use script::detect_script;
 use info::Info;
-use options;
 use options::Options;
 use detect;
 
@@ -39,25 +38,25 @@ pub struct Detector<'a> {
 
 impl<'a> Detector<'a> {
     pub fn new() -> Self {
-        Detector { options: options::DEFAULT }
+        Detector { options: Options::None }
     }
 
     pub fn with_whitelist(whitelist: &'a [Lang]) -> Self {
-        let opts = Options { whitelist: Some(whitelist), blacklist: None };
+        let opts = Options::Whitelist(whitelist);
         Detector { options: opts }
     }
 
     pub fn with_blacklist(blacklist: &'a [Lang]) -> Self {
-        let opts = Options { whitelist: None, blacklist: Some(blacklist) };
+        let opts = Options::Blacklist(blacklist);
         Detector { options: opts }
     }
 
     pub fn detect(&self, text: &str) -> Option<Info> {
-        detect::detect_with_options(text, &self.options)
+        detect::detect_with_options(text, self.options)
     }
 
     pub fn detect_lang(&self, text: &str) -> Option<Lang> {
-        detect::detect_lang_with_options(text, &self.options)
+        detect::detect_lang_with_options(text, self.options)
     }
 
     pub fn detect_script(&self, text: &str) -> Option<Script> {

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,8 +1,14 @@
 use lang::Lang;
 
-pub struct Options<'a> {
-    pub blacklist: Option<&'a [Lang]>,
-    pub whitelist: Option<&'a [Lang]>
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Options<'a> {
+    None,
+    Blacklist(&'a [Lang]),
+    Whitelist(&'a [Lang]),
 }
 
-pub const DEFAULT: Options<'static> = Options { blacklist: None, whitelist: None };
+impl<'a> Default for Options<'a> {
+    fn default() -> Self {
+        Options::None
+    }
+}


### PR DESCRIPTION
Detectors can only be created with either a blacklist or a whitelist. This simply enforces this at the type level.