### PR TITLE
Replace Fnv hash with hashbrown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ include = [
 travis-ci = { repository = "greyblake/whatlang-rs", branch = "master" }
 
 [dependencies]
-fnv = "1.0.6"
+hashbrown = "0.1"
 
 [dev-dependencies]
 serde_json = "1.0.32"

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -1,4 +1,4 @@
-use fnv::FnvHashMap;
+use hashbrown::HashMap;
 
 use lang::*;
 use script::*;
@@ -141,7 +141,7 @@ fn detect_lang_in_profiles(text: &str, options: &Options, lang_profile_list : La
     Some((lang_dist1.0, confidence))
 }
 
-fn calculate_distance(lang_trigrams: LangProfile,  text_trigrams: &FnvHashMap<String, u32>) -> u32 {
+fn calculate_distance(lang_trigrams: LangProfile,  text_trigrams: &HashMap<String, u32>) -> u32 {
     let mut total_dist = 0u32;
 
     for (i, &trigram) in lang_trigrams.iter().enumerate() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! let detector = Detector::with_whitelist(whitelist);
 //! let lang = detector.detect_lang("There is no reason not to learn Esperanto.");
 //! assert_eq!(lang, Some(Lang::Eng));
-extern crate fnv;
+extern crate hashbrown;
 
 mod lang;
 mod script;

--- a/src/trigrams.rs
+++ b/src/trigrams.rs
@@ -1,10 +1,10 @@
 use utils::is_stop_char;
-use fnv::FnvHashMap;
+use hashbrown::HashMap;
 use constants::TEXT_TRIGRAMS_SIZE;
 
 const MAX_INITIAL_HASH_CAPACITY: usize = 2048;
 
-pub fn get_trigrams_with_positions(text : &str) -> FnvHashMap<String, u32> {
+pub fn get_trigrams_with_positions(text : &str) -> HashMap<String, u32> {
 
     // Sort in descending order by number of occurrences and trigrams
     let mut count_vec: Vec<_> = count(text)
@@ -20,9 +20,9 @@ pub fn get_trigrams_with_positions(text : &str) -> FnvHashMap<String, u32> {
         .collect()
 }
 
-fn count(text : &str) -> FnvHashMap<String, u32> {
+fn count(text : &str) -> HashMap<String, u32> {
     let hash_capacity = calculate_initial_hash_capacity(text);
-    let mut counter_hash : FnvHashMap<String, u32> = FnvHashMap::with_capacity_and_hasher(hash_capacity, Default::default());
+    let mut counter_hash : HashMap<String, u32> = HashMap::with_capacity(hash_capacity);
 
     // iterate through the string and count trigrams
     let mut chars_iter = text.chars().map(to_trigram_char).flat_map(char::to_lowercase).chain(Some(' '));


### PR DESCRIPTION
Benchmarks:

Current fnv hasher:
```
running 2 tests
test bench_detect        ... bench:  24,701,919 ns/iter (+/- 2,825,460)
test bench_detect_script ... bench:     260,610 ns/iter (+/- 50,405)
```

Hashbrown hasher:
```
running 2 tests
test bench_detect        ... bench:  17,802,449 ns/iter (+/- 528,879)
test bench_detect_script ... bench:     266,517 ns/iter (+/- 10,377)
```

So it looks like with `hashbrown` the detection algorithm works ~28% faster than with `fnv` hasher.