### PR TITLE
differentiate between mandarin and japanese with whitelist or blackli…

### DIFF
--- a/src/detect.rs
+++ b/src/detect.rs
@@ -59,7 +59,7 @@ fn detect_lang_based_on_script(
         Script::Hebrew => detect_lang_in_profiles(text, options, HEBREW_LANGS),
         Script::Ethiopic => detect_lang_in_profiles(text, options, ETHIOPIC_LANGS),
         Script::Arabic => detect_lang_in_profiles(text, options, ARABIC_LANGS),
-        Script::Mandarin => Some((Lang::Cmn, 1.0)),
+        Script::Mandarin => detect_mandarin_japanese(text, options),
         Script::Bengali => Some((Lang::Ben, 1.0)),
         Script::Hangul => Some((Lang::Kor, 1.0)),
         Script::Georgian => Some((Lang::Kat, 1.0)),
@@ -163,6 +163,30 @@ fn calculate_distance(lang_trigrams: LangProfile, text_trigrams: &HashMap<String
     total_dist
 }
 
+fn detect_mandarin_japanese(text: &str, options: &Options) -> Option<(Lang, f64)> {
+    match options.list {
+        Some(List::White(ref whitelist)) => {
+            if whitelist.contains(&Lang::Jpn) && !whitelist.contains(&Lang::Cmn) {
+                Some((Lang::Jpn, 1.0))
+            } else if whitelist.contains(&Lang::Cmn) {
+                Some((Lang::Cmn, 1.0))
+            } else {
+                None
+            }
+        },
+        Some(List::Black(ref blacklist)) => {
+            if blacklist.contains(&Lang::Cmn) && !blacklist.contains(&Lang::Jpn) {
+                Some((Lang::Jpn, 1.0))
+            } else if !blacklist.contains(&Lang::Cmn) {
+                Some((Lang::Cmn, 1.0))
+            } else {
+                None
+            }
+        },
+        _ => Some((Lang::Cmn, 1.0))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -233,6 +257,36 @@ mod tests {
         assert_eq!(output.is_some(), true);
         let info = output.unwrap();
         assert_eq!(info.lang, Lang::Epo);
+    }
+
+    #[test]
+    fn test_detect_with_options_with_whitelist_mandarin_japanese() {
+        let jpn_opts = Options::new().set_whitelist(vec![Lang::Jpn]);
+
+        let text = "水";
+
+        let info = detect_with_options(text, &jpn_opts).unwrap();
+        assert_eq!(info.lang(), Lang::Jpn);
+
+        let cmn_opts = Options::new().set_whitelist(vec![Lang::Cmn]);
+
+        let info = detect_with_options(text, &cmn_opts).unwrap();
+        assert_eq!(info.lang(), Lang::Cmn);
+    }
+
+    #[test]
+    fn test_detect_with_options_with_blacklist_mandarin_japanese() {
+        let jpn_opts = Options::new().set_blacklist(vec![Lang::Jpn]);
+
+        let text = "水";
+
+        let info = detect_with_options(text, &jpn_opts).unwrap();
+        assert_eq!(info.lang(), Lang::Cmn);
+
+        let cmn_opts = Options::new().set_blacklist(vec![Lang::Cmn]);
+
+        let info = detect_with_options(text, &cmn_opts).unwrap();
+        assert_eq!(info.lang(), Lang::Jpn);
     }
 
     #[test]


### PR DESCRIPTION
Fixes issue #44 

This assumes that if the text contains any "hiragana" or "katakana" characters, it will go to `Script::Japanese`

Because the text will consist solely of `Mandarin` characters, this only adds checks for whitelist and blacklist logic.
If no whitelist or blacklist is supplied, this what would previously have been returned: `Some((Lang::Cmn, 1.0))`