### PR TITLE
return &'static str from Lang::code

### DIFF
--- a/src/lang.rs
+++ b/src/lang.rs
@@ -5093,7 +5093,7 @@ impl Lang {
     /// use whatlang::Lang;
     /// assert_eq!(Lang::Ukr.code(), "ukr");
     /// ```
-    pub fn code(&self) -> &str {
+    pub fn code(&self) -> &'static str {
         lang_to_code(*self)
     }
 


### PR DESCRIPTION
The underlying function returns a &'static str, why not keep it `'static'?