### PR TITLE
Make crate no_std compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ install:
   - rustup component add rustfmt
   - rustup component add clippy
 script:
+  - cargo check --no-default-features
   - cargo fmt -- --check
   - cargo clippy -- -D warnings
   - cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ serde_json = "1.0.39"
 bencher = "0.1.5"
 proptest = "0.9.1"
 
+[features]
+default = ["std"]
+std = []
+
 [[bench]]
 name = "example"
 harness = false

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use hashbrown::HashMap;
 
 use crate::constants::{MAX_TOTAL_DISTANCE, MAX_TRIGRAM_DISTANCE};
@@ -84,7 +85,7 @@ fn detect_lang_in_profiles(
     options: &Options,
     lang_profile_list: LangProfileList,
 ) -> Option<(Lang, f64)> {
-    let mut lang_distances: Vec<(Lang, u32)> = vec![];
+    let mut lang_distances: Vec<(Lang, u32)> = Vec::new();
     let trigrams = get_trigrams_with_positions(text);
 
     for &(ref lang, lang_trigrams) in lang_profile_list {

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use crate::detect;
 use crate::info::Info;
 use crate::lang::Lang;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
-use std::error::Error as StdError;
-use std::fmt::{self, Display};
+use core::fmt::{self, Display};
+use alloc::string::String;
 
 #[derive(Debug)]
 pub enum Error {
@@ -20,4 +20,5 @@ impl Display for Error {
     }
 }
 
-impl StdError for Error {}
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -2,8 +2,9 @@
 //    This file is generated automatically.
 //    Edit misc/lang.rs.erb template instead of editing lang.rs file directly.
 
-use std::fmt;
-use std::str::FromStr;
+use core::fmt;
+use core::str::FromStr;
+use alloc::string::String;
 
 use crate::error::Error;
 use crate::trigrams::Trigram;
@@ -19045,6 +19046,8 @@ impl FromStr for Lang {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        #[cfg(not(feature = "std"))]
+        use alloc::string::ToString;
         Lang::from_code(s).ok_or_else(|| Error::ParseLang(s.to_string()))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,12 @@
 //! let lang = detector.detect_lang("There is no reason not to learn Esperanto.");
 //! assert_eq!(lang, Some(Lang::Eng));
 //!
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate core;
+extern crate alloc;
+
 mod constants;
 mod detect;
 mod detector;

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,4 +1,5 @@
 use crate::lang::Lang;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum List {

--- a/src/scripts/script.rs
+++ b/src/scripts/script.rs
@@ -1,5 +1,5 @@
-use std::fmt;
-use std::str::FromStr;
+use core::fmt;
+use core::str::FromStr;
 
 use super::lang_mapping;
 use crate::error::Error;
@@ -125,6 +125,8 @@ impl FromStr for Script {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        #[cfg(not(feature = "std"))]
+        use crate::alloc::string::ToString;
         match s.to_lowercase().trim() {
             "latin" => Ok(Script::Latin),
             "cyrillic" => Ok(Script::Cyrillic),

--- a/src/trigrams.rs
+++ b/src/trigrams.rs
@@ -1,4 +1,5 @@
 use hashbrown::HashMap;
+use alloc::vec::Vec;
 
 use crate::constants::TEXT_TRIGRAMS_SIZE;
 use crate::utils::is_stop_char;


### PR DESCRIPTION
This patch makes the crate compatible on `no_std` (embedded) environments. The API stays the same. If possible, please publish a new version after merging.