### PR TITLE
Use RefCell for interior mutability of Text::lowercase()

### DIFF
--- a/src/alphabets/detection.rs
+++ b/src/alphabets/detection.rs
@@ -3,7 +3,7 @@ use super::{cyrillic, latin};
 use crate::core::{calculate_confidence, FilterList, Info, InternalQuery, LowercaseText};
 use crate::Lang;
 
-pub fn detect(iquery: &mut InternalQuery) -> Option<Info> {
+pub fn detect(iquery: &InternalQuery) -> Option<Info> {
     let raw_outcome = raw_detect(iquery);
     let RawOutcome { count, scores, .. } = raw_outcome;
 
@@ -22,10 +22,10 @@ pub fn detect(iquery: &mut InternalQuery) -> Option<Info> {
     })
 }
 
-pub fn raw_detect(iquery: &mut InternalQuery) -> RawOutcome {
+pub fn raw_detect(iquery: &InternalQuery) -> RawOutcome {
     use crate::scripts::grouping::MultiLangScript as MLS;
 
-    let text: &LowercaseText = iquery.text.lowercase();
+    let text: &LowercaseText = &iquery.text.lowercase();
     let filter_list: &FilterList = &iquery.filter_list;
     match iquery.multi_lang_script {
         MLS::Cyrillic => cyrillic::alphabet_calculate_scores(text, filter_list),

--- a/src/combined/mod.rs
+++ b/src/combined/mod.rs
@@ -10,7 +10,7 @@ pub struct RawOutcome {
     pub trigram_raw_outcome: trigrams::RawOutcome,
 }
 
-pub fn detect(iquery: &mut InternalQuery) -> Option<Info> {
+pub fn detect(iquery: &InternalQuery) -> Option<Info> {
     let raw_outcome = raw_detect(iquery);
 
     let count = raw_outcome.trigram_raw_outcome.trigrams_count;
@@ -32,7 +32,7 @@ pub fn detect(iquery: &mut InternalQuery) -> Option<Info> {
 }
 
 // TODO: optimize!
-pub fn raw_detect(iquery: &mut InternalQuery) -> RawOutcome {
+pub fn raw_detect(iquery: &InternalQuery) -> RawOutcome {
     let alphabet_raw_outcome = alphabets::raw_detect(iquery);
     let trigram_raw_outcome = trigrams::raw_detect(iquery);
 

--- a/src/core/detect.rs
+++ b/src/core/detect.rs
@@ -59,11 +59,11 @@ fn detect_by_query_based_on_script(
     query: &Query,
     multi_lang_script: MultiLangScript,
 ) -> Option<Info> {
-    let mut iquery = query.to_internal(multi_lang_script);
+    let iquery = query.to_internal(multi_lang_script);
     match query.method {
-        Method::Alphabet => alphabets::detect(&mut iquery),
-        Method::Trigram => trigrams::detect(&mut iquery),
-        Method::Combined => combined::detect(&mut iquery),
+        Method::Alphabet => alphabets::detect(&iquery),
+        Method::Trigram => trigrams::detect(&iquery),
+        Method::Combined => combined::detect(&iquery),
     }
 }
 

--- a/src/core/text.rs
+++ b/src/core/text.rs
@@ -1,6 +1,5 @@
+use std::cell::{Ref, RefCell};
 use std::ops::Deref;
-use std::cell::RefCell;
-use std::cell::Ref;
 
 #[derive(Debug)]
 pub struct LowercaseText {

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -41,8 +41,8 @@ pub fn raw_detect(text: &str) -> RawInfo {
         .map(|script| match script.to_lang_group() {
             ScriptLangGroup::One(lang) => RawLangInfo::OneScript(lang),
             ScriptLangGroup::Multi(multi_lang_script) => {
-                let mut iquery = query.to_internal(multi_lang_script);
-                let combined = combined_raw_detect(&mut iquery);
+                let iquery = query.to_internal(multi_lang_script);
+                let combined = combined_raw_detect(&iquery);
                 RawLangInfo::MultiScript(combined)
             }
             ScriptLangGroup::Mandarin => {

--- a/src/trigrams/detection.rs
+++ b/src/trigrams/detection.rs
@@ -15,7 +15,7 @@ pub struct RawOutcome {
     pub scores: Vec<(Lang, f64)>,
 }
 
-pub fn detect(iquery: &mut InternalQuery) -> Option<Info> {
+pub fn detect(iquery: &InternalQuery) -> Option<Info> {
     let raw_outcome = raw_detect(iquery);
     let RawOutcome {
         trigrams_count,
@@ -40,9 +40,9 @@ pub fn detect(iquery: &mut InternalQuery) -> Option<Info> {
     })
 }
 
-pub fn raw_detect(iquery: &mut InternalQuery) -> RawOutcome {
+pub fn raw_detect(iquery: &InternalQuery) -> RawOutcome {
     let lang_profile_list = script_to_lang_profile_list(iquery.multi_lang_script);
-    calculate_scores_in_profiles(&mut iquery.text, &iquery.filter_list, lang_profile_list)
+    calculate_scores_in_profiles(&iquery.text, &iquery.filter_list, lang_profile_list)
 }
 
 fn script_to_lang_profile_list(script: MultiLangScript) -> LangProfileList {
@@ -57,7 +57,7 @@ fn script_to_lang_profile_list(script: MultiLangScript) -> LangProfileList {
 }
 
 fn calculate_scores_in_profiles(
-    text: &mut Text,
+    text: &Text,
     filter_list: &FilterList,
     lang_profile_list: LangProfileList,
 ) -> RawOutcome {
@@ -126,12 +126,12 @@ mod tests {
     #[test]
     fn test_when_german_is_given() {
         let text = "Die Ordnung muss für immer in diesem Codebase bleiben";
-        let mut iq = InternalQuery {
+        let iq = InternalQuery {
             text: Text::new(text),
             filter_list: &FilterList::default(),
             multi_lang_script: MultiLangScript::Latin,
         };
-        let raw_outcome = raw_detect(&mut iq);
+        let raw_outcome = raw_detect(&iq);
 
         assert_eq!(raw_outcome.trigrams_count, 50);
 


### PR DESCRIPTION
Fixes #99 

## Benchmark

Performance of `detect` seems to be improved, without any logical reason behind it:

In master:
```
test bench_detect        ... bench:   9,174,526 ns/iter (+/- 523,063)
test bench_detect_script ... bench:     122,001 ns/iter (+/- 11,498)
```

In this branch:
```
test bench_detect        ... bench:   8,858,362 ns/iter (+/- 418,497)
test bench_detect_script ... bench:     126,096 ns/iter (+/- 16,487)
```

The benchmarks are consistently   reproducible.