### PR TITLE
Remove unnecessary borrows

### DIFF
--- a/src/alphabets/detection.rs
+++ b/src/alphabets/detection.rs
@@ -26,7 +26,7 @@ pub fn raw_detect(iquery: &InternalQuery) -> RawOutcome {
     use crate::scripts::grouping::MultiLangScript as MLS;
 
     let text: &LowercaseText = &iquery.text.lowercase();
-    let filter_list: &FilterList = &iquery.filter_list;
+    let filter_list: &FilterList = iquery.filter_list;
     match iquery.multi_lang_script {
         MLS::Cyrillic => cyrillic::alphabet_calculate_scores(text, filter_list),
         MLS::Latin => latin::alphabet_calculate_scores(text, filter_list),

--- a/src/trigrams/detection.rs
+++ b/src/trigrams/detection.rs
@@ -42,7 +42,7 @@ pub fn detect(iquery: &InternalQuery) -> Option<Info> {
 
 pub fn raw_detect(iquery: &InternalQuery) -> RawOutcome {
     let lang_profile_list = script_to_lang_profile_list(iquery.multi_lang_script);
-    calculate_scores_in_profiles(&iquery.text, &iquery.filter_list, lang_profile_list)
+    calculate_scores_in_profiles(&iquery.text, iquery.filter_list, lang_profile_list)
 }
 
 fn script_to_lang_profile_list(script: MultiLangScript) -> LangProfileList {


### PR DESCRIPTION
iquery.filter_list does not need to be borrowed in this scenario