### PR TITLE
bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,13 @@ include = [
 github-actions = { repository = "greyblake/whatlang-rs", worklfow = "CI", branch = "master" }
 
 [dependencies]
-hashbrown = "0.7"
-enum-map = { version = "0.6", optional = true }
+hashbrown = "0.11.2"
+enum-map = { version = "1.1.1", optional = true }
 
 [dev-dependencies]
-serde_json = "1.0.39"
+serde_json = "1.0.73"
 bencher = "0.1.5"
-proptest = "0.9.1"
+proptest = "1.0.0"
 
 [features]
 dev = []


### PR DESCRIPTION
Instead of getting rid of hashbrown dependency (#98), upgrade to the latest release instead.

Also upgraded enum-map, serde_json and proptest to their latest release.