### PR TITLE
Main dependencies upgrades with more inlines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,13 @@ include = [
 github-actions = { repository = "greyblake/whatlang-rs", worklfow = "CI", branch = "master" }
 
 [dependencies]
-hashbrown = "0.7"
-enum-map = { version = "0.6", optional = true }
+hashbrown = "0.11.2"
+enum-map = { version = "1.1.1", optional = true }
 
 [dev-dependencies]
-serde_json = "1.0.39"
+serde_json = "1.0.73"
 bencher = "0.1.5"
-proptest = "0.9.1"
+proptest = "1.0.0"
 
 [features]
 dev = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ hashbrown = "0.11.2"
 enum-map = { version = "1.1.1", optional = true }
 
 [dev-dependencies]
-serde_json = "1.0.73"
+serde_json = "1.0.39"
 bencher = "0.1.5"
-proptest = "1.0.0"
+proptest = "0.9.1"
 
 [features]
 dev = []

--- a/src/trigrams/detection.rs
+++ b/src/trigrams/detection.rs
@@ -15,6 +15,7 @@ pub struct RawOutcome {
     pub scores: Vec<(Lang, f64)>,
 }
 
+#[inline]
 pub fn detect(iquery: &InternalQuery) -> Option<Info> {
     let raw_outcome = raw_detect(iquery);
     let RawOutcome {
@@ -40,6 +41,7 @@ pub fn detect(iquery: &InternalQuery) -> Option<Info> {
     })
 }
 
+#[inline]
 pub fn raw_detect(iquery: &InternalQuery) -> RawOutcome {
     let lang_profile_list = script_to_lang_profile_list(iquery.multi_lang_script);
     calculate_scores_in_profiles(&iquery.text, iquery.filter_list, lang_profile_list)
@@ -56,6 +58,7 @@ fn script_to_lang_profile_list(script: MultiLangScript) -> LangProfileList {
     }
 }
 
+#[inline]
 fn calculate_scores_in_profiles(
     text: &Text,
     filter_list: &FilterList,
@@ -93,6 +96,7 @@ fn calculate_scores_in_profiles(
     }
 }
 
+#[inline]
 fn calculate_distance(lang_trigrams: LangProfile, text_trigrams: &HashMap<Trigram, u32>) -> u32 {
     let mut total_dist = 0u32;
 
@@ -114,6 +118,7 @@ fn calculate_distance(lang_trigrams: LangProfile, text_trigrams: &HashMap<Trigra
     total_dist.clamp(0, MAX_TOTAL_DISTANCE)
 }
 
+#[inline]
 fn distance_to_raw_score(distance: u32, max_distance: u32) -> f64 {
     let similarity = max_distance - distance;
     similarity as f64 / max_distance as f64

--- a/src/trigrams/utils.rs
+++ b/src/trigrams/utils.rs
@@ -12,6 +12,7 @@ pub struct TrigramsWithPositions {
     pub(crate) trigram_positions: HashMap<Trigram, u32>,
 }
 
+#[inline]
 pub fn get_trigrams_with_positions(text: &LowercaseText) -> TrigramsWithPositions {
     let CountResult {
         total_trigrams,
@@ -24,6 +25,7 @@ pub fn get_trigrams_with_positions(text: &LowercaseText) -> TrigramsWithPosition
     }
 }
 
+#[inline]
 #[allow(clippy::unnecessary_sort_by)]
 fn trigram_occurances_to_positions(
     trigram_occurances: HashMap<Trigram, u32>,
@@ -48,6 +50,7 @@ struct CountResult {
     trigram_occurances: HashMap<Trigram, u32>,
 }
 
+#[inline]
 fn count(text: &LowercaseText) -> CountResult {
     let hash_capacity = calculate_initial_hash_capacity(text);
     let mut trigram_occurances: HashMap<Trigram, u32> = HashMap::with_capacity(hash_capacity);
@@ -92,6 +95,7 @@ fn to_trigram_char(ch: char) -> char {
 
 // In order to improve performance, define the initial capacity for trigrams hash map,
 // based on the size of the input text.
+#[inline]
 fn calculate_initial_hash_capacity(text: &str) -> usize {
     let len = text.len();
     if len > MAX_INITIAL_HASH_CAPACITY {


### PR DESCRIPTION
Out of curiosity @greyblake, I gave it another go and upgraded hashmap and enum-map to the latest releases, and left the dev-dependencies alone.

After sprinkling more `#[inline]`s, the performance is a bit better.

```
running 2 tests
test bench_detect        ... bench:   8,508,715 ns/iter (+/- 571,452)
test bench_detect_script ... bench:     238,753 ns/iter (+/- 17,187)

running 2 tests
test bench_detect        ... bench:   8,378,025 ns/iter (+/- 856,485)
test bench_detect_script ... bench:     237,377 ns/iter (+/- 12,368)

running 2 tests
test bench_detect        ... bench:   8,408,746 ns/iter (+/- 738,716)
test bench_detect_script ... bench:     236,423 ns/iter (+/- 44,616)
```
Creating this PR just in case you want to bump the main dependencies to the latest maintained releases without the huge performance regression.