### PR TITLE
Optimize latin languages detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ github-actions = { repository = "greyblake/whatlang-rs", workflow = "CI", branch
 
 [dependencies]
 hashbrown = "0.7"
+once_cell = "1.10.0"
 enum-map = { version = "0.6", optional = true }
 
 [dev-dependencies]

--- a/misc/alphabets/calculate_scores.rs.erb
+++ b/misc/alphabets/calculate_scores.rs.erb
@@ -43,7 +43,7 @@ pub fn alphabet_calculate_scores(text: &str) -> Outcome {
         }
     }
 
-    raw_scores.sort_by(|a, b| b.1.cmp(&a.1));
+    raw_scores.sort_unstable_by(|a, b| b.1.cmp(&a.1));
 
     let raw_scores: Vec<(Lang, usize)> = raw_scores
         .into_iter()

--- a/misc/alphabets/calculate_scores.rs.erb
+++ b/misc/alphabets/calculate_scores.rs.erb
@@ -1,3 +1,5 @@
+use std::cmp::Reverse;
+
 use super::Outcome;
 use crate::utils::is_stop_char;
 use crate::core::{LowercaseText, FilterList};
@@ -43,7 +45,7 @@ pub fn alphabet_calculate_scores(text: &str) -> Outcome {
         }
     }
 
-    raw_scores.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    raw_scores.sort_unstable_by_key(|(_, score)| Reverse(*score));
 
     let raw_scores: Vec<(Lang, usize)> = raw_scores
         .into_iter()

--- a/misc/alphabets/latin_gen.rb
+++ b/misc/alphabets/latin_gen.rb
@@ -26,7 +26,7 @@ def load_alphabets
     alphabets[code] = normalize_alphabet(alphabet)
   end
 
-  alphabets.sort_by {|k, _| k }.to_h
+  alphabets.sort_unstable_by {|k, _| k }.to_h
 end
 
 

--- a/misc/alphabets/latin_gen.rb
+++ b/misc/alphabets/latin_gen.rb
@@ -26,7 +26,7 @@ def load_alphabets
     alphabets[code] = normalize_alphabet(alphabet)
   end
 
-  alphabets.sort_unstable_by {|k, _| k }.to_h
+  alphabets.sort_by {|k, _| k }.to_h
 end
 
 

--- a/src/alphabets/cyrillic.rs
+++ b/src/alphabets/cyrillic.rs
@@ -1,3 +1,5 @@
+use std::cmp::Reverse;
+
 use super::RawOutcome;
 use crate::core::{FilterList, LowercaseText};
 use crate::{Lang, Script};
@@ -35,7 +37,7 @@ pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList)
         }
     }
 
-    raw_scores.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    raw_scores.sort_unstable_by_key(|(_, score)| Reverse(*score));
 
     let raw_scores: Vec<(Lang, usize)> = raw_scores
         .into_iter()

--- a/src/alphabets/cyrillic.rs
+++ b/src/alphabets/cyrillic.rs
@@ -35,7 +35,7 @@ pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList)
         }
     }
 
-    raw_scores.sort_by(|a, b| b.1.cmp(&a.1));
+    raw_scores.sort_unstable_by(|a, b| b.1.cmp(&a.1));
 
     let raw_scores: Vec<(Lang, usize)> = raw_scores
         .into_iter()

--- a/src/alphabets/latin.rs
+++ b/src/alphabets/latin.rs
@@ -107,11 +107,11 @@ pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList)
     let char_lang = &*ALPHABET_LANG_MAP;
     let max_raw_score = text.chars().filter(|&ch| !is_stop_char(ch)).count();
 
-    let mut raw_scores: Vec<(Lang, i32)> = Script::Latin
+    let mut raw_scores: Vec<(Lang, usize)> = Script::Latin
         .langs()
         .iter()
         .filter(|&&l| filter_list.is_allowed(l))
-        .map(|&l| (l, 0i32 - max_raw_score as i32))
+        .map(|&l| (l, 0))
         .collect();
 
     for ch in text.chars() {
@@ -130,18 +130,11 @@ pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList)
 
     raw_scores.sort_unstable_by(|a, b| b.1.cmp(&a.1));
 
-    let raw_scores: Vec<(Lang, usize)> = raw_scores
-        .into_iter()
-        .map(|(l, s)| {
-            let score = if s < 0 { 0usize } else { s as usize };
-            (l, score)
-        })
-        .collect();
-
     let mut normalized_scores = vec![];
 
     for &(lang, raw_score) in &raw_scores {
-        let normalized_score = raw_score as f64 / max_raw_score as f64;
+        let normalized_score =
+            raw_score.saturating_sub(max_raw_score) as f64 / max_raw_score as f64;
         normalized_scores.push((lang, normalized_score));
     }
 

--- a/src/alphabets/latin.rs
+++ b/src/alphabets/latin.rs
@@ -3,6 +3,9 @@ use crate::core::{FilterList, LowercaseText};
 use crate::utils::is_stop_char;
 use crate::{Lang, Script};
 
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+
 const AFR: &str = "abcdefghijklmnopqrstuvwxyzáèéêëíîïóôúû";
 const AKA: &str = "abdefghiklmnoprstuwyɔɛ";
 const AZE: &str = "abcdefghijklmnopqrstuvxyzçöüğışə̇";
@@ -41,71 +44,86 @@ const VIE: &str =
     "abcdefghijklmnopqrstuvwxyzàáâãèéêìíòóôõùúýăđĩũơưạảấầẩẫậắằẳẵặẹẻẽếềểễệỉịọỏốồổỗộớờởỡợụủứừửữựỳỵỷỹ";
 const ZUL: &str = "abcdefghijklmnopqrstuvwxyz";
 
-fn get_lang_chars(lang: Lang) -> Vec<char> {
-    let alphabet = match lang {
-        Lang::Afr => AFR,
-        Lang::Aka => AKA,
-        Lang::Aze => AZE,
-        Lang::Cat => CAT,
-        Lang::Ces => CES,
-        Lang::Dan => DAN,
-        Lang::Deu => DEU,
-        Lang::Eng => ENG,
-        Lang::Epo => EPO,
-        Lang::Est => EST,
-        Lang::Fin => FIN,
-        Lang::Fra => FRA,
-        Lang::Hrv => HRV,
-        Lang::Hun => HUN,
-        Lang::Ind => IND,
-        Lang::Ita => ITA,
-        Lang::Jav => JAV,
-        Lang::Lat => LAT,
-        Lang::Lav => LAV,
-        Lang::Lit => LIT,
-        Lang::Nld => NLD,
-        Lang::Nob => NOB,
-        Lang::Pol => POL,
-        Lang::Por => POR,
-        Lang::Ron => RON,
-        Lang::Slk => SLK,
-        Lang::Slv => SLV,
-        Lang::Sna => SNA,
-        Lang::Spa => SPA,
-        Lang::Swe => SWE,
-        Lang::Tgl => TGL,
-        Lang::Tuk => TUK,
-        Lang::Tur => TUR,
-        Lang::Uzb => UZB,
-        Lang::Vie => VIE,
-        Lang::Zul => ZUL,
+const LATIN_ALPHABETS: &[(Lang, &str)] = &[
+    (Lang::Afr, AFR),
+    (Lang::Aka, AKA),
+    (Lang::Aze, AZE),
+    (Lang::Cat, CAT),
+    (Lang::Ces, CES),
+    (Lang::Dan, DAN),
+    (Lang::Deu, DEU),
+    (Lang::Eng, ENG),
+    (Lang::Epo, EPO),
+    (Lang::Est, EST),
+    (Lang::Fin, FIN),
+    (Lang::Fra, FRA),
+    (Lang::Hrv, HRV),
+    (Lang::Hun, HUN),
+    (Lang::Ind, IND),
+    (Lang::Ita, ITA),
+    (Lang::Jav, JAV),
+    (Lang::Lat, LAT),
+    (Lang::Lav, LAV),
+    (Lang::Lit, LIT),
+    (Lang::Nld, NLD),
+    (Lang::Nob, NOB),
+    (Lang::Pol, POL),
+    (Lang::Por, POR),
+    (Lang::Ron, RON),
+    (Lang::Slk, SLK),
+    (Lang::Slv, SLV),
+    (Lang::Sna, SNA),
+    (Lang::Spa, SPA),
+    (Lang::Swe, SWE),
+    (Lang::Tgl, TGL),
+    (Lang::Tuk, TUK),
+    (Lang::Tur, TUR),
+    (Lang::Uzb, UZB),
+    (Lang::Vie, VIE),
+    (Lang::Zul, ZUL),
+];
 
-        _ => panic!("No alphabet for {}", lang),
-    };
-    alphabet.chars().collect()
-}
+/// Inverted map binding a character to a set of languages.
+pub static ALPHABET_LANG_MAP: Lazy<Vec<(char, Vec<Lang>)>> = Lazy::new(|| {
+    let mut map = HashMap::new();
+
+    for (lang, alphabet) in LATIN_ALPHABETS {
+        for c in alphabet.chars() {
+            let entry = map.entry(c).or_insert_with(Vec::new);
+            entry.push(*lang);
+        }
+    }
+
+    let mut char_lang = Vec::new();
+
+    for (ch, languages) in map {
+        char_lang.push((ch, languages));
+    }
+
+    char_lang
+});
 
 pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList) -> RawOutcome {
+    let char_lang = &*ALPHABET_LANG_MAP;
+    let max_raw_score = text.chars().filter(|&ch| !is_stop_char(ch)).count();
+
     let mut raw_scores: Vec<(Lang, i32)> = Script::Latin
         .langs()
         .iter()
         .filter(|&&l| filter_list.is_allowed(l))
-        .map(|&l| (l, 0i32))
+        .map(|&l| (l, 0i32 - max_raw_score as i32))
         .collect();
 
-    let max_raw_score = text.chars().filter(|&ch| !is_stop_char(ch)).count();
+    for ch in text.chars() {
+        if is_stop_char(ch) {
+            continue;
+        }
 
-    for (lang, score) in &mut raw_scores {
-        let alphabet = get_lang_chars(*lang);
-
-        for ch in text.chars() {
-            if is_stop_char(ch) {
-                continue;
-            };
-            if alphabet.contains(&ch) {
-                *score += 1;
-            } else {
-                *score -= 1;
+        if let Some((_, languages)) = char_lang.iter().find(|(c, _)| *c == ch) {
+            for lang in languages {
+                if let Some((_, score)) = raw_scores.iter_mut().find(|(l, _)| l == lang) {
+                    *score += 2;
+                }
             }
         }
     }

--- a/src/alphabets/latin.rs
+++ b/src/alphabets/latin.rs
@@ -110,7 +110,7 @@ pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList)
         }
     }
 
-    raw_scores.sort_by(|a, b| b.1.cmp(&a.1));
+    raw_scores.sort_unstable_by(|a, b| b.1.cmp(&a.1));
 
     let raw_scores: Vec<(Lang, usize)> = raw_scores
         .into_iter()

--- a/src/alphabets/latin.rs
+++ b/src/alphabets/latin.rs
@@ -141,10 +141,10 @@ pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList)
 
     let mut normalized_scores = vec![];
 
-    for &(lang, raw_score) in &raw_scores {
-        let normalized_score =
-            (raw_score + common_score).saturating_sub(max_raw_score) as f64 / max_raw_score as f64;
-        normalized_scores.push((lang, normalized_score));
+    for (lang, raw_score) in raw_scores.iter_mut() {
+        *raw_score = (*raw_score + common_score).saturating_sub(max_raw_score);
+        let normalized_score = *raw_score as f64 / max_raw_score as f64;
+        normalized_scores.push((*lang, normalized_score));
     }
 
     RawOutcome {

--- a/src/alphabets/latin.rs
+++ b/src/alphabets/latin.rs
@@ -100,6 +100,7 @@ pub static ALPHABET_LANG_MAP: Lazy<Vec<(char, Vec<Lang>)>> = Lazy::new(|| {
         char_lang.push((ch, languages));
     }
 
+    char_lang.sort_unstable_by_key(|(c, _)| *c);
     char_lang
 });
 
@@ -120,7 +121,8 @@ pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList)
             continue;
         }
 
-        if let Some((_, languages)) = char_lang.iter().find(|(c, _)| *c == ch) {
+        if let Ok(position) = char_lang.binary_search_by_key(&ch, |(c, _)| *c) {
+            let (_, languages) = &char_lang[position];
             // if this char is common to all Languages, add 2 to a common counter
             // instead of iterating over all Languages counters.
             if languages.len() == LATIN_ALPHABETS.len() {

--- a/src/alphabets/latin.rs
+++ b/src/alphabets/latin.rs
@@ -110,14 +110,17 @@ pub static ALPHABET_LANG_MAP: Lazy<(Vec<char>, Vec<Vec<Lang>>)> = Lazy::new(|| {
 
 pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList) -> RawOutcome {
     let (chars, langs) = &*ALPHABET_LANG_MAP;
-    let max_raw_score = text.chars().filter(|&ch| !is_stop_char(ch)).count();
+    // let max_raw_score = text.chars().filter(|&ch| !is_stop_char(ch)).count();
 
     // score of each character.
+    let mut max_raw_score = 0;
     let mut scores: Vec<_> = chars.iter().map(|_| 0).collect();
     for ch in text.chars() {
         if is_stop_char(ch) {
             continue;
         }
+
+        max_raw_score += 1;
 
         if let Ok(position) = chars.binary_search(&ch) {
             scores[position] += 2;

--- a/src/combined/mod.rs
+++ b/src/combined/mod.rs
@@ -78,7 +78,7 @@ pub fn raw_detect(iquery: &InternalQuery) -> RawOutcome {
         scores.push((lang, score));
     }
 
-    scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Less));
+    scores.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Less));
 
     RawOutcome {
         scores,

--- a/src/scripts/detect.rs
+++ b/src/scripts/detect.rs
@@ -24,7 +24,7 @@ pub struct RawScriptInfo {
 
 impl RawScriptInfo {
     fn new(mut counters: Vec<(Script, usize)>) -> Self {
-        counters.sort_by(|a, b| b.1.cmp(&a.1));
+        counters.sort_unstable_by(|a, b| b.1.cmp(&a.1));
         Self { counters }
     }
 

--- a/src/scripts/detect.rs
+++ b/src/scripts/detect.rs
@@ -1,3 +1,5 @@
+use std::cmp::Reverse;
+
 use super::script::Script;
 use crate::utils::is_stop_char;
 
@@ -24,7 +26,7 @@ pub struct RawScriptInfo {
 
 impl RawScriptInfo {
     fn new(mut counters: Vec<(Script, usize)>) -> Self {
-        counters.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+        counters.sort_unstable_by_key(|(_, score)| Reverse(*score));
         Self { counters }
     }
 

--- a/src/trigrams/detection.rs
+++ b/src/trigrams/detection.rs
@@ -77,7 +77,7 @@ fn calculate_scores_in_profiles(
     }
 
     // Sort languages by distance
-    lang_distances.sort_unstable_by_key(|key| key.1);
+    lang_distances.sort_unstable_by_key(|(_, dist)| *dist);
 
     let max_dist = unique_trigrams_count as u32 * MAX_TRIGRAM_DISTANCE;
 

--- a/src/trigrams/detection.rs
+++ b/src/trigrams/detection.rs
@@ -77,7 +77,7 @@ fn calculate_scores_in_profiles(
     }
 
     // Sort languages by distance
-    lang_distances.sort_by_key(|key| key.1);
+    lang_distances.sort_unstable_by_key(|key| key.1);
 
     let max_dist = unique_trigrams_count as u32 * MAX_TRIGRAM_DISTANCE;
 

--- a/src/trigrams/utils.rs
+++ b/src/trigrams/utils.rs
@@ -33,7 +33,7 @@ fn trigram_occurances_to_positions(
         .into_iter()
         .map(|(trigram, count)| (count, trigram))
         .collect();
-    count_vec.sort_by(|a, b| b.cmp(a));
+    count_vec.sort_unstable_by(|a, b| b.cmp(a));
 
     count_vec
         .into_iter()


### PR DESCRIPTION
# Summary

Optimize `alphabet_calculate_scores` function used during Latin Language detection.

Compute the score in two steps:
-  iterate over the text and scores character based on their frequency
- then sum the character's scores in Language's scores

This avoids imbricated loops that make the compute complexity quadratic.

For now, I didn't do anything on the trigrams part, the behavior is more complicated to understand. 😅
But, I will probably try to optimize it in another PR.

# Whatlang benchmarks

## main branch

    test bench_detect        ... bench:   8,120,987 ns/iter (+/- 119,807)
    test bench_detect_script ... bench:     102,829 ns/iter (+/- 1,600)
    
    test latin alphabet only ... bench:   3,533,305 ns/iter (+/- 102,068)

## Commits
### Replace sort_by
    test bench_detect        ... bench:   7,984,651 ns/iter (+/- 82,686)
    test bench_detect_script ... bench:      93,662 ns/iter (+/- 2,249)
    
    test latin alphabet only ... bench:   3,542,116 ns/iter (+/- 45,714)

### Use inverted mapping between char and Lang
    test bench_detect        ... bench:   7,642,256 ns/iter (+/- 91,700)
    test bench_detect_script ... bench:      94,344 ns/iter (+/- 2,501)

    test latin alphabet only ... bench:   3,221,397 ns/iter (+/- 32,611)

### Clamp score in normalization loop instead of creating intermediate vec

    test bench_detect        ... bench:   7,594,489 ns/iter (+/- 95,791)
    test bench_detect_script ... bench:      98,816 ns/iter (+/- 2,039)
    
    test latin alphabet only ... bench:   3,333,266 ns/iter (+/- 29,036)
    
### Increment a common score when a common char is found

    test bench_detect        ... bench:   5,190,589 ns/iter (+/- 73,054)
    test bench_detect_script ... bench:      98,731 ns/iter (+/- 1,395)
    
    test latin alphabet only ... bench:     846,625 ns/iter (+/- 13,893)
    
### Use binary search instead of iter find

    test bench_detect        ... bench:   4,992,537 ns/iter (+/- 77,899)
    test bench_detect_script ... bench:      99,535 ns/iter (+/- 5,190)
    
    test latin alphabet only ... bench:     575,347 ns/iter (+/- 7,259)
    
### Fix returned raw score

    test bench_detect        ... bench:   4,999,493 ns/iter (+/- 69,303)
    test bench_detect_script ... bench:      93,847 ns/iter (+/- 1,339)
    
    test latin alphabet only ... bench:     580,022 ns/iter (+/- 7,469)

### Use intermediate char score

    test bench_detect        ... bench:   4,802,885 ns/iter (+/- 73,186)
    test bench_detect_script ... bench:      93,860 ns/iter (+/- 2,912)
    
    test latin alphabet only ... bench:     388,278 ns/iter (+/- 4,427)

### Count Max score in char score Loop

    test bench_detect        ... bench:   4,837,791 ns/iter (+/- 71,111)
    test bench_detect_script ... bench:      94,130 ns/iter (+/- 715)
    
    test latin alphabet only ... bench:     354,250 ns/iter (+/- 11,778)
    
### Make lang score access O(1) when iterating over char scores

    test bench_detect        ... bench:   4,769,341 ns/iter (+/- 78,060)
    test bench_detect_script ... bench:      93,748 ns/iter (+/- 706)
    
    test latin alphabet only ... bench:     308,811 ns/iter (+/- 10,769)