### PR TITLE
simplify alphabet_calculate_scores

### DIFF
--- a/src/alphabets/cyrillic.rs
+++ b/src/alphabets/cyrillic.rs
@@ -12,6 +12,9 @@ const MKD: &str = "абвгдежзиклмнопрстуфхцчшѓѕјљњќ�
 
 const ALL: &str = "абвгдежзийклмнопрстуфхцчшщъыьэюяёєіїґўђјљњћџѓѕќ";
 
+fn is_relevant(ch: char) -> bool {
+    ALL.chars().any(|c| c == ch)
+}
 fn calculate_char_score(ch: char, alphabet: &Vec<char>) -> i32 {
     if !is_relevant(ch) {
         0
@@ -21,6 +24,7 @@ fn calculate_char_score(ch: char, alphabet: &Vec<char>) -> i32 {
         -1
     }
 }
+
 fn calculate_lang_score(lang: &Lang, text: &LowercaseText) -> usize {
     let alphabet = get_lang_chars(*lang);
     let score: i32 = text
@@ -29,24 +33,6 @@ fn calculate_lang_score(lang: &Lang, text: &LowercaseText) -> usize {
         .sum();
 
     cmp::max(score, 0) as usize
-}
-
-fn is_relevant(ch: char) -> bool {
-    ALL.chars().any(|c| c == ch)
-}
-
-fn get_lang_chars(lang: Lang) -> Vec<char> {
-    let alphabet = match lang {
-        Lang::Bul => BUL,
-        Lang::Rus => RUS,
-        Lang::Ukr => UKR,
-        Lang::Bel => BEL,
-        Lang::Srp => SRP,
-        Lang::Mkd => MKD,
-
-        _ => panic!("No alphabet for {}", lang),
-    };
-    alphabet.chars().collect()
 }
 
 pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList) -> RawOutcome {
@@ -72,6 +58,20 @@ pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList)
         raw_scores,
         scores: normalized_scores,
     }
+}
+
+fn get_lang_chars(lang: Lang) -> Vec<char> {
+    let alphabet = match lang {
+        Lang::Bul => BUL,
+        Lang::Rus => RUS,
+        Lang::Ukr => UKR,
+        Lang::Bel => BEL,
+        Lang::Srp => SRP,
+        Lang::Mkd => MKD,
+
+        _ => panic!("No alphabet for {}", lang),
+    };
+    alphabet.chars().collect()
 }
 
 #[cfg(test)]

--- a/src/alphabets/cyrillic.rs
+++ b/src/alphabets/cyrillic.rs
@@ -41,6 +41,24 @@ fn normalize_score(raw_score: usize, max_raw_score: usize) -> f64 {
     }
 }
 
+fn is_relevant(ch: char) -> bool {
+    ALL.chars().any(|c| c == ch)
+}
+
+fn get_lang_chars(lang: Lang) -> Vec<char> {
+    let alphabet = match lang {
+        Lang::Bul => BUL,
+        Lang::Rus => RUS,
+        Lang::Ukr => UKR,
+        Lang::Bel => BEL,
+        Lang::Srp => SRP,
+        Lang::Mkd => MKD,
+
+        _ => panic!("No alphabet for {}", lang),
+    };
+    alphabet.chars().collect()
+}
+
 pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList) -> RawOutcome {
     let max_raw_score = text.chars().filter(|&ch| is_relevant(ch)).count();
     let raw_scores: Vec<(Lang, usize)> = Script::Cyrillic
@@ -63,24 +81,6 @@ pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList)
         raw_scores,
         scores: normalized_scores,
     }
-}
-
-fn is_relevant(ch: char) -> bool {
-    ALL.chars().any(|c| c == ch)
-}
-
-fn get_lang_chars(lang: Lang) -> Vec<char> {
-    let alphabet = match lang {
-        Lang::Bul => BUL,
-        Lang::Rus => RUS,
-        Lang::Ukr => UKR,
-        Lang::Bel => BEL,
-        Lang::Srp => SRP,
-        Lang::Mkd => MKD,
-
-        _ => panic!("No alphabet for {}", lang),
-    };
-    alphabet.chars().collect()
 }
 
 #[cfg(test)]

--- a/src/alphabets/cyrillic.rs
+++ b/src/alphabets/cyrillic.rs
@@ -1,6 +1,6 @@
 use super::RawOutcome;
 use crate::core::{FilterList, LowercaseText};
-use crate::{Lang, Script};
+use crate::{alphabets, Lang, Script};
 
 const BUL: &str = "абвгдежзийклмнопрстуфхцчшщъьюя";
 const RUS: &str = "абвгдежзийклмнопрстуфхцчшщъыьэюяё";
@@ -30,14 +30,6 @@ fn calculate_lang_score(lang: &Lang, text: &LowercaseText) -> usize {
         0usize
     } else {
         score as usize
-    }
-}
-
-fn normalize_score(raw_score: usize, max_raw_score: usize) -> f64 {
-    if raw_score == 0 {
-        0.0
-    } else {
-        raw_score as f64 / max_raw_score as f64
     }
 }
 
@@ -73,7 +65,7 @@ pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList)
 
     let normalized_scores = raw_scores
         .iter()
-        .map(|&(lang, raw_score)| (lang, normalize_score(raw_score, max_raw_score)))
+        .map(|&(lang, raw_score)| (lang, alphabets::normalize_score(raw_score, max_raw_score)))
         .collect();
 
     RawOutcome {

--- a/src/alphabets/latin.rs
+++ b/src/alphabets/latin.rs
@@ -1,7 +1,7 @@
 use super::RawOutcome;
 use crate::core::{FilterList, LowercaseText};
 use crate::utils::is_stop_char;
-use crate::{Lang, Script};
+use crate::{alphabets, Lang, Script};
 
 const AFR: &str = "abcdefghijklmnopqrstuvwxyzáèéêëíîïóôúû";
 const AKA: &str = "abdefghiklmnoprstuwyɔɛ";
@@ -108,15 +108,6 @@ fn calculate_lang_score(lang: &Lang, text: &LowercaseText) -> usize {
     }
 }
 
-fn normalize_score(raw_score: usize, max_raw_score: usize) -> f64 {
-    // TODO: merge with normalize_score from cyrillic.rs
-    if raw_score == 0 {
-        0.0
-    } else {
-        raw_score as f64 / max_raw_score as f64
-    }
-}
-
 pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList) -> RawOutcome {
     let max_raw_score = text.chars().filter(|&ch| !is_stop_char(ch)).count();
 
@@ -132,7 +123,7 @@ pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList)
 
     let normalized_scores = raw_scores
         .iter()
-        .map(|&(lang, raw_score)| (lang, normalize_score(raw_score, max_raw_score)))
+        .map(|&(lang, raw_score)| (lang, alphabets::normalize_score(raw_score, max_raw_score)))
         .collect();
 
     RawOutcome {

--- a/src/alphabets/latin.rs
+++ b/src/alphabets/latin.rs
@@ -85,47 +85,55 @@ fn get_lang_chars(lang: Lang) -> Vec<char> {
     alphabet.chars().collect()
 }
 
-pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList) -> RawOutcome {
-    let mut raw_scores: Vec<(Lang, i32)> = Script::Latin
-        .langs()
-        .iter()
-        .filter(|&&l| filter_list.is_allowed(l))
-        .map(|&l| (l, 0i32))
-        .collect();
+fn calculate_lang_score(lang: &Lang, text: &LowercaseText) -> usize {
+    // TODO: merge with calculate_lang_score from cyrillic.rs
+    let alphabet = get_lang_chars(*lang);
+    let score: i32 = text
+        .chars()
+        .map(|ch| {
+            if !is_stop_char(ch) {
+                0
+            } else if alphabet.contains(&ch) {
+                1
+            } else {
+                -1
+            }
+        })
+        .sum();
 
+    if score < 0 {
+        0usize
+    } else {
+        score as usize
+    }
+}
+
+fn normalize_score(raw_score: usize, max_raw_score: usize) -> f64 {
+    // TODO: merge with normalize_score from cyrillic.rs
+    if raw_score == 0 {
+        0.0
+    } else {
+        raw_score as f64 / max_raw_score as f64
+    }
+}
+
+pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList) -> RawOutcome {
     let max_raw_score = text.chars().filter(|&ch| !is_stop_char(ch)).count();
 
-    for (lang, score) in &mut raw_scores {
-        let alphabet = get_lang_chars(*lang);
-
-        for ch in text.chars() {
-            if is_stop_char(ch) {
-                continue;
-            };
-            if alphabet.contains(&ch) {
-                *score += 1;
-            } else {
-                *score -= 1;
-            }
-        }
-    }
-
-    raw_scores.sort_by(|a, b| b.1.cmp(&a.1));
-
-    let raw_scores: Vec<(Lang, usize)> = raw_scores
-        .into_iter()
-        .map(|(l, s)| {
-            let score = if s < 0 { 0usize } else { s as usize };
-            (l, score)
-        })
+    let raw_scores: Vec<(Lang, usize)> = Script::Latin
+        .langs()
+        .iter()
+        .filter(|&&lang| filter_list.is_allowed(lang))
+        .map(|&lang| (lang, calculate_lang_score(&lang, text)))
         .collect();
 
-    let mut normalized_scores = vec![];
+    // FIXME: You never use the fact that vector is sorted, at least tests don't fail
+    // raw_scores.sort_by(|a, b| b.1.cmp(&a.1));
 
-    for &(lang, raw_score) in &raw_scores {
-        let normalized_score = raw_score as f64 / max_raw_score as f64;
-        normalized_scores.push((lang, normalized_score));
-    }
+    let normalized_scores = raw_scores
+        .iter()
+        .map(|&(lang, raw_score)| (lang, normalize_score(raw_score, max_raw_score)))
+        .collect();
 
     RawOutcome {
         count: max_raw_score,

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -12,3 +12,11 @@ pub struct RawOutcome {
     pub raw_scores: Vec<(Lang, usize)>,
     pub scores: Vec<(Lang, f64)>,
 }
+
+fn normalize_score(raw_score: usize, max_raw_score: usize) -> f64 {
+    if raw_score == 0 {
+        0.0
+    } else {
+        raw_score as f64 / max_raw_score as f64
+    }
+}


### PR DESCRIPTION
Refactor alphabet_calculate_scores to use iterators instead of for loops;
extract simple functions