### PR TITLE
Move latin table generation to compile time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ include = [
 
 [dependencies]
 hashbrown = "0.12.0"
-once_cell = "1.10.0"
 enum-map = { version = "1.1.1", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["text-processing", "algorithms"]
 include = [
     "src/**/*",
     "test/**/*",
+    "build.rs",
     "Cargo.toml",
     "README.md"
 ]

--- a/build.rs
+++ b/build.rs
@@ -84,7 +84,6 @@ const LATIN_ALPHABETS: &[(&str, &str)] = &[
 
 fn main() {
     // Build latin lookup table
-
     let mut map = HashMap::new();
 
     for (lang, alphabet) in LATIN_ALPHABETS {

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,129 @@
+use std::collections::HashMap;
+use std::env;
+use std::fs::File;
+use std::io::BufWriter;
+use std::io::Write;
+use std::path::Path;
+
+const AFR: &str = "abcdefghijklmnopqrstuvwxyzáèéêëíîïóôúû";
+const AKA: &str = "abdefghiklmnoprstuwyɔɛ";
+const AZE: &str = "abcdefghijklmnopqrstuvxyzçöüğışə̇";
+const CAT: &str = "abcdefghijklmnopqrstuvwxyz·àçèéíïòóúü";
+const CES: &str = "abcdefghijklmnopqrstuvwxyzáéóúýčďěňřšťůž";
+const DAN: &str = "abcdefghijklmnopqrstuvwxyzåæø";
+const DEU: &str = "abcdefghijklmnopqrstuvwxyzßäöü";
+const ENG: &str = "abcdefghijklmnopqrstuvwxyz";
+const EPO: &str = "abcdefghijklmnoprstuvzĉĝĥĵŝŭ";
+const EST: &str = "abcdefghijklmnopqrstuvwxyzäõöü";
+const FIN: &str = "abcdefghijklmnopqrstuvwxyzäöšž";
+const FRA: &str = "abcdefghijklmnopqrstuvwxyzàâçèéêëîïôùûüÿœ";
+const HRV: &str = "abcdefghijklmnopqrstuvwxyzćčđšž";
+const HUN: &str = "abcdefghijklmnopqrstuvwxyzáéíóöúüőű";
+const IND: &str = "abcdefghijklmnopqrstuvwxyz";
+const ITA: &str = "abcdefghijklmnopqrstuvwxyzàèéìòù";
+const JAV: &str = "abcdefghijklmnopqrstuvwxyzèé";
+const LAT: &str = "abcdefghijklmnopqrstuvwxyz";
+const LAV: &str = "abcdefghijklmnopqrstuvwxyzāčēģīķļņōŗšūž";
+const LIT: &str = "abcdefghijklmnopqrstuvwxyząčėęįšūųž";
+const NLD: &str = "abcdefghijklmnopqrstuvwxyzàèéëïĳ";
+const NOB: &str = "abcdefghijklmnopqrstuvwxyzåæø";
+const POL: &str = "abcdefghijklmnopqrstuvwxyzóąćęłńśźż";
+const POR: &str = "abcdefghijklmnopqrstuvwxyzàáâãçéêíóôõú";
+const RON: &str = "abcdefghijklmnopqrstuvwxyzâîăşţ";
+const SLK: &str = "abcdefghijklmnopqrstuvwxyzáäéíóôúýčďĺľňŕšťž";
+const SLV: &str = "abcdefghijklmnopqrstuvwxyzčšž";
+const SNA: &str = "abcdefghijklmnopqrstuvwxyz";
+const SPA: &str = "abcdefghijklmnopqrstuvwxyz¡¿áéíñóúü";
+const SWE: &str = "abcdefghijklmnopqrstuvwxyzäåö";
+const TGL: &str = "abcdefghijklmnopqrstuvwxyzáéíñóú";
+const TUK: &str = "abdefghijklmnoprstuwyzäçöüýňşž";
+const TUR: &str = "abcdefghijklmnopqrstuvwxyzçöüğış̇";
+const UZB: &str = "abcdefghijklmnopqrstuvxyzʻ";
+const VIE: &str =
+    "abcdefghijklmnopqrstuvwxyzàáâãèéêìíòóôõùúýăđĩũơưạảấầẩẫậắằẳẵặẹẻẽếềểễệỉịọỏốồổỗộớờởỡợụủứừửữựỳỵỷỹ";
+const ZUL: &str = "abcdefghijklmnopqrstuvwxyz";
+
+const LATIN_ALPHABETS: &[(&str, &str)] = &[
+    ("Lang::Afr", AFR),
+    ("Lang::Aka", AKA),
+    ("Lang::Aze", AZE),
+    ("Lang::Cat", CAT),
+    ("Lang::Ces", CES),
+    ("Lang::Dan", DAN),
+    ("Lang::Deu", DEU),
+    ("Lang::Eng", ENG),
+    ("Lang::Epo", EPO),
+    ("Lang::Est", EST),
+    ("Lang::Fin", FIN),
+    ("Lang::Fra", FRA),
+    ("Lang::Hrv", HRV),
+    ("Lang::Hun", HUN),
+    ("Lang::Ind", IND),
+    ("Lang::Ita", ITA),
+    ("Lang::Jav", JAV),
+    ("Lang::Lat", LAT),
+    ("Lang::Lav", LAV),
+    ("Lang::Lit", LIT),
+    ("Lang::Nld", NLD),
+    ("Lang::Nob", NOB),
+    ("Lang::Pol", POL),
+    ("Lang::Por", POR),
+    ("Lang::Ron", RON),
+    ("Lang::Slk", SLK),
+    ("Lang::Slv", SLV),
+    ("Lang::Sna", SNA),
+    ("Lang::Spa", SPA),
+    ("Lang::Swe", SWE),
+    ("Lang::Tgl", TGL),
+    ("Lang::Tuk", TUK),
+    ("Lang::Tur", TUR),
+    ("Lang::Uzb", UZB),
+    ("Lang::Vie", VIE),
+    ("Lang::Zul", ZUL),
+];
+
+fn main() {
+    // Build latin lookup table
+
+    let mut map = HashMap::new();
+
+    for (lang, alphabet) in LATIN_ALPHABETS {
+        for c in alphabet.chars() {
+            let entry = map.entry(c).or_insert_with(Vec::new);
+            entry.push(*lang);
+        }
+    }
+
+    let mut char_lang: Vec<_> = map.into_iter().collect();
+
+    char_lang.sort_unstable_by_key(|(c, _)| *c);
+
+    let mut chars = Vec::with_capacity(char_lang.len());
+    let mut langs = Vec::with_capacity(char_lang.len());
+
+    for (ch, languages) in char_lang {
+        chars.push(ch);
+        langs.push(languages);
+    }
+
+    let path = Path::new(&env::var_os("OUT_DIR").unwrap()).join("latin_table.rs");
+    let mut file = BufWriter::new(File::create(path).unwrap());
+    writeln!(file, "const LATIN_LANG_COUNT: usize = {};", chars.len()).unwrap();
+
+    writeln!(file, "const LATIN_CHARS: [char; LATIN_LANG_COUNT] = [").unwrap();
+    for ch in chars {
+        writeln!(file, "    {:?},", ch).unwrap();
+    }
+    writeln!(file, "];").unwrap();
+    writeln!(file).unwrap();
+
+    writeln!(
+        file,
+        "const LATIN_LANG_BY_CHAR: [&[Lang]; LATIN_LANG_COUNT] = ["
+    )
+    .unwrap();
+    for langs_for_char in langs {
+        writeln!(file, "    &[{}],", langs_for_char.join(", ")).unwrap();
+    }
+    writeln!(file, "];").unwrap();
+}

--- a/misc/lang.rs.erb
+++ b/misc/lang.rs.erb
@@ -5,7 +5,7 @@
 use std::fmt;
 use std::str::FromStr;
 
-use crate::error::Error;
+use crate::error::ParseError;
 
 #[cfg(feature = "enum-map")]
 use enum_map::Enum;
@@ -35,21 +35,21 @@ fn lang_from_code<S: Into<String>>(code: S) -> Option<Lang> {
     }
 }
 
-fn lang_to_code(lang: Lang) -> &'static str {
+const fn lang_to_code(lang: Lang) -> &'static str {
     match lang {
         <% langs.each do |lang| %>
         Lang::<%= lang.code.capitalize %> => "<%= lang.code %>",<% end %>
     }
 }
 
-fn lang_to_name(lang: Lang) -> &'static str {
+const fn lang_to_name(lang: Lang) -> &'static str {
     match lang {
         <% langs.each do |lang| %>
         Lang::<%= lang.code.capitalize %> => "<%= lang.name %>",<% end %>
     }
 }
 
-fn lang_to_eng_name(lang: Lang) -> &'static str {
+const fn lang_to_eng_name(lang: Lang) -> &'static str {
     match lang {
         <% langs.each do |lang| %>
         Lang::<%= lang.code.capitalize %> => "<%= lang.eng_name %>",<% end %>
@@ -75,7 +75,7 @@ impl Lang {
     /// use whatlang::Lang;
     /// assert_eq!(Lang::Ukr.code(), "ukr");
     /// ```
-    pub fn code(&self) -> &'static str {
+    pub const fn code(&self) -> &'static str {
         lang_to_code(*self)
     }
 
@@ -86,7 +86,7 @@ impl Lang {
     /// use whatlang::Lang;
     /// assert_eq!(Lang::Ukr.name(), "Українська");
     /// ```
-    pub fn name(self) -> &'static str {
+    pub const fn name(self) -> &'static str {
         lang_to_name(self)
     }
 
@@ -97,7 +97,7 @@ impl Lang {
     /// use whatlang::Lang;
     /// assert_eq!(Lang::Deu.eng_name(), "German");
     /// ```
-    pub fn eng_name(self) -> &'static str {
+    pub const fn eng_name(self) -> &'static str {
         lang_to_eng_name(self)
     }
 
@@ -110,7 +110,7 @@ impl Lang {
     ///     println!("{}", lang);
     /// }
     /// ```
-    pub fn all() -> &'static [Lang] {
+    pub const fn all() -> &'static [Lang] {
         &VALUES
     }
 }
@@ -122,10 +122,10 @@ impl fmt::Display for Lang {
 }
 
 impl FromStr for Lang {
-    type Err = Error;
+    type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Lang::from_code(s).ok_or_else(|| Error::ParseLang(s.to_string()))
+        Lang::from_code(s).ok_or_else(|| ParseError::Lang(s.to_string()))
     }
 }
 
@@ -181,7 +181,7 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(Error::ParseLang(_))
+                Err(ParseError::Lang(_))
             )
         );
     }

--- a/src/alphabets/latin.rs
+++ b/src/alphabets/latin.rs
@@ -86,7 +86,7 @@ const LATIN_ALPHABETS: &[(Lang, &str)] = &[
 ];
 
 /// Inverted map binding a character to a set of languages.
-pub static ALPHABET_LANG_MAP: Lazy<(Vec<char>, Vec<Vec<Lang>>)> = Lazy::new(|| {
+static ALPHABET_LANG_MAP: Lazy<(Vec<char>, Vec<Vec<Lang>>)> = Lazy::new(|| {
     let mut map = HashMap::new();
 
     for (lang, alphabet) in LATIN_ALPHABETS {

--- a/src/alphabets/latin.rs
+++ b/src/alphabets/latin.rs
@@ -59,7 +59,7 @@ pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList)
 
     raw_scores.sort_unstable_by_key(|(_, score)| Reverse(*score));
 
-    let mut normalized_scores = vec![];
+    let mut normalized_scores = Vec::with_capacity(raw_scores.len());
 
     for &(lang, raw_score) in raw_scores.iter() {
         let normalized_score = raw_score as f64 / max_raw_score as f64;

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -364,7 +364,7 @@ fn lang_from_code<S: Into<String>>(code: S) -> Option<Lang> {
     }
 }
 
-fn lang_to_code(lang: Lang) -> &'static str {
+const fn lang_to_code(lang: Lang) -> &'static str {
     match lang {
         Lang::Epo => "epo",
         Lang::Eng => "eng",
@@ -437,7 +437,7 @@ fn lang_to_code(lang: Lang) -> &'static str {
     }
 }
 
-fn lang_to_name(lang: Lang) -> &'static str {
+const fn lang_to_name(lang: Lang) -> &'static str {
     match lang {
         Lang::Epo => "Esperanto",
         Lang::Eng => "English",
@@ -510,7 +510,7 @@ fn lang_to_name(lang: Lang) -> &'static str {
     }
 }
 
-fn lang_to_eng_name(lang: Lang) -> &'static str {
+const fn lang_to_eng_name(lang: Lang) -> &'static str {
     match lang {
         Lang::Epo => "Esperanto",
         Lang::Eng => "English",
@@ -602,7 +602,7 @@ impl Lang {
     /// use whatlang::Lang;
     /// assert_eq!(Lang::Ukr.code(), "ukr");
     /// ```
-    pub fn code(&self) -> &'static str {
+    pub const fn code(&self) -> &'static str {
         lang_to_code(*self)
     }
 
@@ -613,7 +613,7 @@ impl Lang {
     /// use whatlang::Lang;
     /// assert_eq!(Lang::Ukr.name(), "Українська");
     /// ```
-    pub fn name(self) -> &'static str {
+    pub const fn name(self) -> &'static str {
         lang_to_name(self)
     }
 
@@ -624,7 +624,7 @@ impl Lang {
     /// use whatlang::Lang;
     /// assert_eq!(Lang::Deu.eng_name(), "German");
     /// ```
-    pub fn eng_name(self) -> &'static str {
+    pub const fn eng_name(self) -> &'static str {
         lang_to_eng_name(self)
     }
 

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -637,7 +637,7 @@ impl Lang {
     ///     println!("{}", lang);
     /// }
     /// ```
-    pub fn all() -> &'static [Lang] {
+    pub const fn all() -> &'static [Lang] {
         &VALUES
     }
 }

--- a/src/scripts/lang_mapping.rs
+++ b/src/scripts/lang_mapping.rs
@@ -51,7 +51,7 @@ const ARABIC_LANGS: [Lang; 3] = [Lang::Ara, Lang::Urd, Lang::Pes];
 const DEVANAGARI_LANGS: [Lang; 3] = [Lang::Hin, Lang::Mar, Lang::Nep];
 const HEBREW_LANGS: [Lang; 2] = [Lang::Heb, Lang::Yid];
 
-pub fn script_langs(script: Script) -> &'static [Lang] {
+pub const fn script_langs(script: Script) -> &'static [Lang] {
     match script {
         Script::Latin => &LATIN_LANGS,
         Script::Cyrillic => &CYRILLIC_LANGS,

--- a/src/scripts/script.rs
+++ b/src/scripts/script.rs
@@ -77,11 +77,11 @@ impl Script {
     ///     println!("{}", script);
     /// }
     /// ```
-    pub fn all() -> &'static [Script] {
+    pub const fn all() -> &'static [Script] {
         &VALUES
     }
 
-    pub fn name(&self) -> &str {
+    pub const fn name(&self) -> &'static str {
         match *self {
             Script::Latin => "Latin",
             Script::Cyrillic => "Cyrillic",
@@ -110,7 +110,7 @@ impl Script {
         }
     }
 
-    pub fn langs(&self) -> &[Lang] {
+    pub const fn langs(&self) -> &'static [Lang] {
         lang_mapping::script_langs(*self)
     }
 }


### PR DESCRIPTION
Rather than a `once_cell::Lazy`, build the known latin chars, and corresponding list of languages per character at compile time, with a build script. This removes the once_cell dependency.

Additionally, mark some functions on `Lang`/`Script` as const where possible. This allows e.g. building an array of `[T; Lang::all().len()]`.