### PR TITLE
Using generic function to compute alphabet score for Cyrillic and latin

### DIFF
--- a/src/alphabets/cyrillic.rs
+++ b/src/alphabets/cyrillic.rs
@@ -13,21 +13,14 @@ mod tests {
     use super::*;
     use crate::Lang;
 
-    const CYRILLIC_LANGS: [Lang; 6] = [
-        Lang::Rus,
-        Lang::Ukr,
-        Lang::Srp,
-        Lang::Bel,
-        Lang::Mkd,
-        Lang::Bul,
-    ];
-
     fn fetch<T: Copy>(lang: &Lang, scores: &[(Lang, T)]) -> T {
         scores.iter().find(|(l, _)| l == lang).unwrap().1
     }
 
     #[test]
     fn test_when_latin_is_given() {
+        let cyrillic_langs: &[Lang] = Script::Cyrillic.langs();
+
         let text = LowercaseText::new("Foobar, hoh");
         let RawOutcome {
             count,
@@ -36,15 +29,15 @@ mod tests {
         } = alphabet_calculate_scores(&text, &FilterList::default());
 
         assert_eq!(count, 0);
-        assert_eq!(raw_scores.len(), CYRILLIC_LANGS.len());
-        assert_eq!(scores.len(), CYRILLIC_LANGS.len());
+        assert_eq!(raw_scores.len(), cyrillic_langs.len());
+        assert_eq!(scores.len(), cyrillic_langs.len());
 
-        for lang in &CYRILLIC_LANGS {
+        for lang in cyrillic_langs {
             let raw_score = fetch(lang, &raw_scores);
             assert_eq!(raw_score, 0);
         }
 
-        for lang in &CYRILLIC_LANGS {
+        for lang in cyrillic_langs {
             let score = fetch(lang, &scores);
             assert_eq!(score, 0.0);
         }
@@ -52,6 +45,8 @@ mod tests {
 
     #[test]
     fn test_when_common_cyrllic_is_given() {
+        let cyrillic_langs: &[Lang] = Script::Cyrillic.langs();
+
         let text = LowercaseText::new("абвг ww");
         let RawOutcome {
             count,
@@ -61,12 +56,12 @@ mod tests {
 
         assert_eq!(count, 4);
 
-        for lang in &CYRILLIC_LANGS {
+        for lang in cyrillic_langs {
             let raw_score = fetch(lang, &raw_scores);
             assert_eq!(raw_score, 4);
         }
 
-        for lang in &CYRILLIC_LANGS {
+        for lang in cyrillic_langs {
             let score = fetch(lang, &scores);
             assert_eq!(score, 1.0);
         }

--- a/src/alphabets/cyrillic.rs
+++ b/src/alphabets/cyrillic.rs
@@ -5,7 +5,7 @@ use crate::Script;
 
 pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList) -> RawOutcome {
     let all_langs = Script::Cyrillic.langs();
-    generic::alphabet_calculate_scores_generic_slow(text, filter_list, all_langs)
+    generic::alphabet_calculate_scores_generic(text, filter_list, all_langs)
 }
 
 #[cfg(test)]

--- a/src/alphabets/cyrillic.rs
+++ b/src/alphabets/cyrillic.rs
@@ -1,101 +1,17 @@
-use std::cmp::Reverse;
-
 use super::RawOutcome;
-use crate::alphabets::generic::{get_all_chars_in_langs, get_lang_chars, is_relevant_for_langs};
+use crate::alphabets::generic;
 use crate::core::{FilterList, LowercaseText};
-use crate::{Lang, Script};
-
-const BUL: &str = "абвгдежзийклмнопрстуфхцчшщъьюя";
-const RUS: &str = "абвгдежзийклмнопрстуфхцчшщъыьэюяё";
-const UKR: &str = "абвгдежзийклмнопрстуфхцчшщьюяєіїґ";
-const BEL: &str = "абвгдежзйклмнопрстуфхцчшыьэюяёіў";
-const SRP: &str = "абвгдежзиклмнопрстуфхцчшђјљњћџ";
-const MKD: &str = "абвгдежзиклмнопрстуфхцчшѓѕјљњќџ";
-
-const ALL: &str = "абвгдежзийклмнопрстуфхцчшщъыьэюяёєіїґўђјљњћџѓѕќ";
+use crate::Script;
 
 pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList) -> RawOutcome {
-    let mut raw_scores: Vec<(Lang, i32)> = Script::Cyrillic
-        .langs()
-        .iter()
-        .filter(|&&l| filter_list.is_allowed(l))
-        .map(|&l| (l, 0i32))
-        .collect();
-
     let all_langs = Script::Cyrillic.langs();
-    let all_chars_in_langs = get_all_chars_in_langs(all_langs);
-
-    // let max_raw_score = text.chars().filter(|&ch| is_relevant(ch)).count();
-    let max_raw_score = text
-        .chars()
-        .filter(|&ch| is_relevant_for_langs(&ch, &all_chars_in_langs))
-        .count();
-
-    for (lang, score) in &mut raw_scores {
-        let alphabet = get_lang_chars(*lang);
-
-        for ch in text.chars() {
-            // if !is_relevant(ch) {
-            if !is_relevant_for_langs(&ch, &all_chars_in_langs) {
-                continue;
-            } else if alphabet.contains(&ch) {
-                *score += 1;
-            } else {
-                *score -= 1;
-            }
-        }
-    }
-
-    raw_scores.sort_unstable_by_key(|(_, score)| Reverse(*score));
-
-    let raw_scores: Vec<(Lang, usize)> = raw_scores
-        .into_iter()
-        .map(|(l, s)| {
-            let score = if s < 0 { 0usize } else { s as usize };
-            (l, score)
-        })
-        .collect();
-
-    let mut normalized_scores = vec![];
-
-    for &(lang, raw_score) in &raw_scores {
-        // avoid devision by zero
-        let normalized_score = if raw_score == 0 {
-            0.0
-        } else {
-            raw_score as f64 / max_raw_score as f64
-        };
-        normalized_scores.push((lang, normalized_score));
-    }
-
-    RawOutcome {
-        count: max_raw_score,
-        raw_scores,
-        scores: normalized_scores,
-    }
+    generic::alphabet_calculate_scores_generic(text, filter_list, all_langs)
 }
-
-// fn is_relevant(ch: char) -> bool {
-//     ALL.chars().any(|c| c == ch)
-// }
-//
-// fn get_lang_chars(lang: Lang) -> Vec<char> {
-//     let alphabet = match lang {
-//         Lang::Bul => BUL,
-//         Lang::Rus => RUS,
-//         Lang::Ukr => UKR,
-//         Lang::Bel => BEL,
-//         Lang::Srp => SRP,
-//         Lang::Mkd => MKD,
-//
-//         _ => panic!("No alphabet for {}", lang),
-//     };
-//     alphabet.chars().collect()
-// }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Lang;
 
     const CYRILLIC_LANGS: [Lang; 6] = [
         Lang::Rus,

--- a/src/alphabets/cyrillic.rs
+++ b/src/alphabets/cyrillic.rs
@@ -1,6 +1,7 @@
 use std::cmp::Reverse;
 
 use super::RawOutcome;
+use crate::alphabets::generic::{get_all_chars_in_langs, get_lang_chars, is_relevant_for_langs};
 use crate::core::{FilterList, LowercaseText};
 use crate::{Lang, Script};
 
@@ -21,13 +22,21 @@ pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList)
         .map(|&l| (l, 0i32))
         .collect();
 
-    let max_raw_score = text.chars().filter(|&ch| is_relevant(ch)).count();
+    let all_langs = Script::Cyrillic.langs();
+    let all_chars_in_langs = get_all_chars_in_langs(all_langs);
+
+    // let max_raw_score = text.chars().filter(|&ch| is_relevant(ch)).count();
+    let max_raw_score = text
+        .chars()
+        .filter(|&ch| is_relevant_for_langs(&ch, &all_chars_in_langs))
+        .count();
 
     for (lang, score) in &mut raw_scores {
         let alphabet = get_lang_chars(*lang);
 
         for ch in text.chars() {
-            if !is_relevant(ch) {
+            // if !is_relevant(ch) {
+            if !is_relevant_for_langs(&ch, &all_chars_in_langs) {
                 continue;
             } else if alphabet.contains(&ch) {
                 *score += 1;
@@ -66,23 +75,23 @@ pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList)
     }
 }
 
-fn is_relevant(ch: char) -> bool {
-    ALL.chars().any(|c| c == ch)
-}
-
-fn get_lang_chars(lang: Lang) -> Vec<char> {
-    let alphabet = match lang {
-        Lang::Bul => BUL,
-        Lang::Rus => RUS,
-        Lang::Ukr => UKR,
-        Lang::Bel => BEL,
-        Lang::Srp => SRP,
-        Lang::Mkd => MKD,
-
-        _ => panic!("No alphabet for {}", lang),
-    };
-    alphabet.chars().collect()
-}
+// fn is_relevant(ch: char) -> bool {
+//     ALL.chars().any(|c| c == ch)
+// }
+//
+// fn get_lang_chars(lang: Lang) -> Vec<char> {
+//     let alphabet = match lang {
+//         Lang::Bul => BUL,
+//         Lang::Rus => RUS,
+//         Lang::Ukr => UKR,
+//         Lang::Bel => BEL,
+//         Lang::Srp => SRP,
+//         Lang::Mkd => MKD,
+//
+//         _ => panic!("No alphabet for {}", lang),
+//     };
+//     alphabet.chars().collect()
+// }
 
 #[cfg(test)]
 mod tests {

--- a/src/alphabets/cyrillic.rs
+++ b/src/alphabets/cyrillic.rs
@@ -5,7 +5,7 @@ use crate::Script;
 
 pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList) -> RawOutcome {
     let all_langs = Script::Cyrillic.langs();
-    generic::alphabet_calculate_scores_generic(text, filter_list, all_langs)
+    generic::alphabet_calculate_scores_generic_slow(text, filter_list, all_langs)
 }
 
 #[cfg(test)]

--- a/src/alphabets/generic.rs
+++ b/src/alphabets/generic.rs
@@ -49,7 +49,7 @@ const VIE: &str =
     "abcdefghijklmnopqrstuvwxyzàáâãèéêìíòóôõùúýăđĩũơưạảấầẩẫậắằẳẵặẹẻẽếềểễệỉịọỏốồổỗộớờởỡợụủứừửữựỳỵỷỹ";
 const ZUL: &str = "abcdefghijklmnopqrstuvwxyz";
 
-pub fn get_lang_chars(lang: Lang) -> Vec<char> {
+pub fn get_lang_chars(lang: &Lang) -> Vec<char> {
     let alphabet = match lang {
         Lang::Bul => BUL,
         Lang::Rus => RUS,
@@ -101,7 +101,7 @@ pub fn get_lang_chars(lang: Lang) -> Vec<char> {
 pub fn get_all_chars_in_langs(langs: &[Lang]) -> HashSet<char> {
     langs
         .iter()
-        .flat_map(|&lang| get_lang_chars(lang))
+        .flat_map(|&lang| get_lang_chars(&lang))
         .collect()
 }
 
@@ -116,8 +116,8 @@ mod tests {
 
     #[test]
     fn test_get_lang_chars() {
-        assert_eq!(get_lang_chars(Lang::Bul).len(), 30);
-        assert_eq!(get_lang_chars(Lang::Rus).len(), 33);
+        assert_eq!(get_lang_chars(&Lang::Bul).len(), 30);
+        assert_eq!(get_lang_chars(&Lang::Rus).len(), 33);
         //     TODO: finish tests
     }
 
@@ -161,7 +161,7 @@ pub fn alphabet_calculate_scores_generic(
         .count();
 
     for (lang, score) in &mut raw_scores {
-        let alphabet = get_lang_chars(*lang);
+        let alphabet = get_lang_chars(lang);
 
         for ch in text.chars() {
             // if !is_relevant(ch) {

--- a/src/alphabets/generic.rs
+++ b/src/alphabets/generic.rs
@@ -1,4 +1,4 @@
-use hashbrown::HashSet;
+use std::collections::HashSet;
 use crate::Lang;
 
 const BUL: &str = "абвгдежзийклмнопрстуфхцчшщъьюя";
@@ -99,23 +99,34 @@ pub fn get_all_chars_in_langs(langs: Vec<Lang>) -> HashSet<char> {
     langs.iter().flat_map(|&lang| get_lang_chars(lang)).collect()
 }
 
+pub fn is_relevant_for_langs(ch: &char, chars: &HashSet<char>) -> bool {
+    chars.contains(ch)
+}
+
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use super::*;
 
     #[test]
     fn test_get_lang_chars() {
-
-        assert_eq!( get_lang_chars(Lang::Bul).len() , 30);
-        assert_eq!( get_lang_chars(Lang::Rus).len() , 33);
-    //     TODO: finish tests
+        assert_eq!(get_lang_chars(Lang::Bul).len(), 30);
+        assert_eq!(get_lang_chars(Lang::Rus).len(), 33);
+        //     TODO: finish tests
     }
 
     #[test]
     fn test_get_all_chars_in_langs() {
-        assert_eq!( get_all_chars_in_langs(vec![Lang::Bul, Lang::Rus]).len() , 33);
-        assert_eq!( get_all_chars_in_langs(vec![Lang::Bul, Lang::Rus, Lang::Ukr]).len() , 37);
+        assert_eq!(get_all_chars_in_langs(vec![Lang::Bul, Lang::Rus]).len(), 33);
+        assert_eq!(get_all_chars_in_langs(vec![Lang::Bul, Lang::Rus, Lang::Ukr]).len(), 37);
         // TODO: finish tests
+    }
+
+    #[test]
+    fn test_is_relevant_for_langs() {
+        let chars: HashSet<char> = vec!['a', 'b'].into_iter().collect();
+        assert_eq!(is_relevant_for_langs(&'a', &chars), true);
+        assert_eq!(is_relevant_for_langs(&'c', &chars), false);
     }
 }

--- a/src/alphabets/generic.rs
+++ b/src/alphabets/generic.rs
@@ -109,101 +109,6 @@ pub fn is_relevant_for_langs(ch: &char, chars: &HashSet<char>) -> bool {
     chars.contains(ch)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::collections::HashSet;
-
-    #[test]
-    fn test_get_lang_chars() {
-        assert_eq!(get_lang_chars(&Lang::Bul).len(), 30);
-        assert_eq!(get_lang_chars(&Lang::Rus).len(), 33);
-        //     TODO: finish tests
-    }
-
-    #[test]
-    fn test_get_all_chars_in_langs() {
-        assert_eq!(
-            get_all_chars_in_langs(&vec![Lang::Bul, Lang::Rus]).len(),
-            33
-        );
-        assert_eq!(
-            get_all_chars_in_langs(&vec![Lang::Bul, Lang::Rus, Lang::Ukr]).len(),
-            37
-        );
-        // TODO: finish tests
-    }
-
-    #[test]
-    fn test_is_relevant_for_langs() {
-        let chars: HashSet<char> = vec!['a', 'b'].into_iter().collect();
-        assert_eq!(is_relevant_for_langs(&'a', &chars), true);
-        assert_eq!(is_relevant_for_langs(&'c', &chars), false);
-    }
-}
-
-pub fn alphabet_calculate_scores_generic_slow(
-    text: &LowercaseText,
-    filter_list: &FilterList,
-    all_langs: &[Lang],
-) -> RawOutcome {
-    let all_chars_in_langs = get_all_chars_in_langs(all_langs);
-
-    let mut raw_scores: Vec<(Lang, i32)> = all_langs
-        .iter()
-        .filter(|&&l| filter_list.is_allowed(l))
-        .map(|&l| (l, 0i32))
-        .collect();
-
-    let max_raw_score = text
-        .chars()
-        .filter(|&ch| is_relevant_for_langs(&ch, &all_chars_in_langs))
-        .count();
-
-    for (lang, score) in &mut raw_scores {
-        let alphabet = get_lang_chars(lang);
-
-        for ch in text.chars() {
-            // if !is_relevant(ch) {
-            if !is_relevant_for_langs(&ch, &all_chars_in_langs) {
-                continue;
-            } else if alphabet.contains(&ch) {
-                *score += 1;
-            } else {
-                *score -= 1;
-            }
-        }
-    }
-
-    raw_scores.sort_unstable_by_key(|(_, score)| Reverse(*score));
-
-    let raw_scores: Vec<(Lang, usize)> = raw_scores
-        .into_iter()
-        .map(|(l, s)| {
-            let score = if s < 0 { 0usize } else { s as usize };
-            (l, score)
-        })
-        .collect();
-
-    let mut normalized_scores = vec![];
-
-    for &(lang, raw_score) in &raw_scores {
-        // avoid devision by zero
-        let normalized_score = if raw_score == 0 {
-            0.0
-        } else {
-            raw_score as f64 / max_raw_score as f64
-        };
-        normalized_scores.push((lang, normalized_score));
-    }
-
-    RawOutcome {
-        count: max_raw_score,
-        raw_scores,
-        scores: normalized_scores,
-    }
-}
-
 /// Inverted map binding a character to a set of languages.
 pub fn get_alphabet_lang_map(all_langs: &[Lang]) -> (Vec<char>, Vec<Vec<Lang>>) {
     let mut map = HashMap::new();
@@ -299,5 +204,38 @@ pub fn alphabet_calculate_scores_generic(
         count: max_raw_score,
         raw_scores,
         scores: normalized_scores,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_get_lang_chars() {
+        assert_eq!(get_lang_chars(&Lang::Bul).len(), 30);
+        assert_eq!(get_lang_chars(&Lang::Rus).len(), 33);
+        //     TODO: finish tests
+    }
+
+    #[test]
+    fn test_get_all_chars_in_langs() {
+        assert_eq!(
+            get_all_chars_in_langs(&vec![Lang::Bul, Lang::Rus]).len(),
+            33
+        );
+        assert_eq!(
+            get_all_chars_in_langs(&vec![Lang::Bul, Lang::Rus, Lang::Ukr]).len(),
+            37
+        );
+        // TODO: finish tests
+    }
+
+    #[test]
+    fn test_is_relevant_for_langs() {
+        let chars: HashSet<char> = vec!['a', 'b'].into_iter().collect();
+        assert_eq!(is_relevant_for_langs(&'a', &chars), true);
+        assert_eq!(is_relevant_for_langs(&'c', &chars), false);
     }
 }

--- a/src/alphabets/generic.rs
+++ b/src/alphabets/generic.rs
@@ -1,0 +1,121 @@
+use hashbrown::HashSet;
+use crate::Lang;
+
+const BUL: &str = "абвгдежзийклмнопрстуфхцчшщъьюя";
+const RUS: &str = "абвгдежзийклмнопрстуфхцчшщъыьэюяё";
+const UKR: &str = "абвгдежзийклмнопрстуфхцчшщьюяєіїґ";
+const BEL: &str = "абвгдежзйклмнопрстуфхцчшыьэюяёіў";
+const SRP: &str = "абвгдежзиклмнопрстуфхцчшђјљњћџ";
+const MKD: &str = "абвгдежзиклмнопрстуфхцчшѓѕјљњќџ";
+
+const AFR: &str = "abcdefghijklmnopqrstuvwxyzáèéêëíîïóôúû";
+const AKA: &str = "abdefghiklmnoprstuwyɔɛ";
+const AZE: &str = "abcdefghijklmnopqrstuvxyzçöüğışə̇";
+const CAT: &str = "abcdefghijklmnopqrstuvwxyz·àçèéíïòóúü";
+const CES: &str = "abcdefghijklmnopqrstuvwxyzáéóúýčďěňřšťůž";
+const DAN: &str = "abcdefghijklmnopqrstuvwxyzåæø";
+const DEU: &str = "abcdefghijklmnopqrstuvwxyzßäöü";
+const ENG: &str = "abcdefghijklmnopqrstuvwxyz";
+const EPO: &str = "abcdefghijklmnoprstuvzĉĝĥĵŝŭ";
+const EST: &str = "abcdefghijklmnopqrstuvwxyzäõöü";
+const FIN: &str = "abcdefghijklmnopqrstuvwxyzäöšž";
+const FRA: &str = "abcdefghijklmnopqrstuvwxyzàâçèéêëîïôùûüÿœ";
+const HRV: &str = "abcdefghijklmnopqrstuvwxyzćčđšž";
+const HUN: &str = "abcdefghijklmnopqrstuvwxyzáéíóöúüőű";
+const IND: &str = "abcdefghijklmnopqrstuvwxyz";
+const ITA: &str = "abcdefghijklmnopqrstuvwxyzàèéìòù";
+const JAV: &str = "abcdefghijklmnopqrstuvwxyzèé";
+const LAT: &str = "abcdefghijklmnopqrstuvwxyz";
+const LAV: &str = "abcdefghijklmnopqrstuvwxyzāčēģīķļņōŗšūž";
+const LIT: &str = "abcdefghijklmnopqrstuvwxyząčėęįšūųž";
+const NLD: &str = "abcdefghijklmnopqrstuvwxyzàèéëïĳ";
+const NOB: &str = "abcdefghijklmnopqrstuvwxyzåæø";
+const POL: &str = "abcdefghijklmnopqrstuvwxyzóąćęłńśźż";
+const POR: &str = "abcdefghijklmnopqrstuvwxyzàáâãçéêíóôõú";
+const RON: &str = "abcdefghijklmnopqrstuvwxyzâîăşţ";
+const SLK: &str = "abcdefghijklmnopqrstuvwxyzáäéíóôúýčďĺľňŕšťž";
+const SLV: &str = "abcdefghijklmnopqrstuvwxyzčšž";
+const SNA: &str = "abcdefghijklmnopqrstuvwxyz";
+const SPA: &str = "abcdefghijklmnopqrstuvwxyz¡¿áéíñóúü";
+const SWE: &str = "abcdefghijklmnopqrstuvwxyzäåö";
+const TGL: &str = "abcdefghijklmnopqrstuvwxyzáéíñóú";
+const TUK: &str = "abdefghijklmnoprstuwyzäçöüýňşž";
+const TUR: &str = "abcdefghijklmnopqrstuvwxyzçöüğış̇";
+const UZB: &str = "abcdefghijklmnopqrstuvxyzʻ";
+const VIE: &str =
+    "abcdefghijklmnopqrstuvwxyzàáâãèéêìíòóôõùúýăđĩũơưạảấầẩẫậắằẳẵặẹẻẽếềểễệỉịọỏốồổỗộớờởỡợụủứừửữựỳỵỷỹ";
+const ZUL: &str = "abcdefghijklmnopqrstuvwxyz";
+
+fn get_lang_chars(lang: Lang) -> Vec<char> {
+    let alphabet = match lang {
+        Lang::Bul => BUL,
+        Lang::Rus => RUS,
+        Lang::Ukr => UKR,
+        Lang::Bel => BEL,
+        Lang::Srp => SRP,
+        Lang::Mkd => MKD,
+        Lang::Afr => AFR,
+        Lang::Aka => AKA,
+        Lang::Aze => AZE,
+        Lang::Cat => CAT,
+        Lang::Ces => CES,
+        Lang::Dan => DAN,
+        Lang::Deu => DEU,
+        Lang::Eng => ENG,
+        Lang::Epo => EPO,
+        Lang::Est => EST,
+        Lang::Fin => FIN,
+        Lang::Fra => FRA,
+        Lang::Hrv => HRV,
+        Lang::Hun => HUN,
+        Lang::Ind => IND,
+        Lang::Ita => ITA,
+        Lang::Jav => JAV,
+        Lang::Lat => LAT,
+        Lang::Lav => LAV,
+        Lang::Lit => LIT,
+        Lang::Nld => NLD,
+        Lang::Nob => NOB,
+        Lang::Pol => POL,
+        Lang::Por => POR,
+        Lang::Ron => RON,
+        Lang::Slk => SLK,
+        Lang::Slv => SLV,
+        Lang::Sna => SNA,
+        Lang::Spa => SPA,
+        Lang::Swe => SWE,
+        Lang::Tgl => TGL,
+        Lang::Tuk => TUK,
+        Lang::Tur => TUR,
+        Lang::Uzb => UZB,
+        Lang::Vie => VIE,
+        Lang::Zul => ZUL,
+        _ => panic!("No alphabet for {}", lang),
+    };
+    alphabet.chars().collect()
+}
+
+pub fn get_all_chars_in_langs(langs: Vec<Lang>) -> HashSet<char> {
+    langs.iter().flat_map(|&lang| get_lang_chars(lang)).collect()
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_lang_chars() {
+
+        assert_eq!( get_lang_chars(Lang::Bul).len() , 30);
+        assert_eq!( get_lang_chars(Lang::Rus).len() , 33);
+    //     TODO: finish tests
+    }
+
+    #[test]
+    fn test_get_all_chars_in_langs() {
+        assert_eq!( get_all_chars_in_langs(vec![Lang::Bul, Lang::Rus]).len() , 33);
+        assert_eq!( get_all_chars_in_langs(vec![Lang::Bul, Lang::Rus, Lang::Ukr]).len() , 37);
+        // TODO: finish tests
+    }
+}

--- a/src/alphabets/generic.rs
+++ b/src/alphabets/generic.rs
@@ -1,5 +1,5 @@
-use std::collections::HashSet;
 use crate::Lang;
+use std::collections::HashSet;
 
 const BUL: &str = "абвгдежзийклмнопрстуфхцчшщъьюя";
 const RUS: &str = "абвгдежзийклмнопрстуфхцчшщъыьэюяё";
@@ -46,7 +46,7 @@ const VIE: &str =
     "abcdefghijklmnopqrstuvwxyzàáâãèéêìíòóôõùúýăđĩũơưạảấầẩẫậắằẳẵặẹẻẽếềểễệỉịọỏốồổỗộớờởỡợụủứừửữựỳỵỷỹ";
 const ZUL: &str = "abcdefghijklmnopqrstuvwxyz";
 
-fn get_lang_chars(lang: Lang) -> Vec<char> {
+pub fn get_lang_chars(lang: Lang) -> Vec<char> {
     let alphabet = match lang {
         Lang::Bul => BUL,
         Lang::Rus => RUS,
@@ -95,19 +95,21 @@ fn get_lang_chars(lang: Lang) -> Vec<char> {
     alphabet.chars().collect()
 }
 
-pub fn get_all_chars_in_langs(langs: Vec<Lang>) -> HashSet<char> {
-    langs.iter().flat_map(|&lang| get_lang_chars(lang)).collect()
+pub fn get_all_chars_in_langs(langs: &[Lang]) -> HashSet<char> {
+    langs
+        .iter()
+        .flat_map(|&lang| get_lang_chars(lang))
+        .collect()
 }
 
 pub fn is_relevant_for_langs(ch: &char, chars: &HashSet<char>) -> bool {
     chars.contains(ch)
 }
 
-
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
     use super::*;
+    use std::collections::HashSet;
 
     #[test]
     fn test_get_lang_chars() {
@@ -118,8 +120,14 @@ mod tests {
 
     #[test]
     fn test_get_all_chars_in_langs() {
-        assert_eq!(get_all_chars_in_langs(vec![Lang::Bul, Lang::Rus]).len(), 33);
-        assert_eq!(get_all_chars_in_langs(vec![Lang::Bul, Lang::Rus, Lang::Ukr]).len(), 37);
+        assert_eq!(
+            get_all_chars_in_langs(&vec![Lang::Bul, Lang::Rus]).len(),
+            33
+        );
+        assert_eq!(
+            get_all_chars_in_langs(&vec![Lang::Bul, Lang::Rus, Lang::Ukr]).len(),
+            37
+        );
         // TODO: finish tests
     }
 

--- a/src/alphabets/generic.rs
+++ b/src/alphabets/generic.rs
@@ -2,7 +2,7 @@ use crate::alphabets::RawOutcome;
 use crate::core::{FilterList, LowercaseText};
 use crate::Lang;
 use std::cmp::Reverse;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 const BUL: &str = "абвгдежзийклмнопрстуфхцчшщъьюя";
 const RUS: &str = "абвгдежзийклмнопрстуфхцчшщъыьэюяё";
@@ -142,7 +142,7 @@ mod tests {
     }
 }
 
-pub fn alphabet_calculate_scores_generic(
+pub fn alphabet_calculate_scores_generic_slow(
     text: &LowercaseText,
     filter_list: &FilterList,
     all_langs: &[Lang],
@@ -189,6 +189,104 @@ pub fn alphabet_calculate_scores_generic(
 
     for &(lang, raw_score) in &raw_scores {
         // avoid devision by zero
+        let normalized_score = if raw_score == 0 {
+            0.0
+        } else {
+            raw_score as f64 / max_raw_score as f64
+        };
+        normalized_scores.push((lang, normalized_score));
+    }
+
+    RawOutcome {
+        count: max_raw_score,
+        raw_scores,
+        scores: normalized_scores,
+    }
+}
+
+/// Inverted map binding a character to a set of languages.
+pub fn get_alphabet_lang_map(all_langs: &[Lang]) -> (Vec<char>, Vec<Vec<Lang>>) {
+    let mut map = HashMap::new();
+    for lang in all_langs {
+        let alphabet = get_lang_chars(&lang);
+        for c in alphabet.iter() {
+            let entry = map.entry(*c).or_insert_with(Vec::new);
+            entry.push(*lang);
+        }
+    }
+    let mut char_lang: Vec<_> = map.into_iter().collect();
+    char_lang.sort_unstable_by_key(|(c, _)| *c);
+
+    let mut chars = Vec::with_capacity(char_lang.len());
+    let mut langs = Vec::with_capacity(char_lang.len());
+    for (ch, languages) in char_lang {
+        chars.push(ch);
+        langs.push(languages);
+    }
+
+    (chars, langs)
+}
+
+pub fn alphabet_calculate_scores_generic(
+    text: &LowercaseText,
+    filter_list: &FilterList,
+    all_langs: &[Lang],
+) -> RawOutcome {
+    let all_chars_in_langs = get_all_chars_in_langs(all_langs);
+    let (chars, langs) = get_alphabet_lang_map(all_langs);
+
+    // score of each character.
+    let mut char_scores = vec![0; chars.len()];
+    let mut max_raw_score = 0;
+    // iterate over the text and scores characters.
+    for ch in text.chars() {
+        if !is_relevant_for_langs(&ch, &all_chars_in_langs) {
+            continue;
+        }
+
+        max_raw_score += 1;
+
+        if let Ok(position) = chars.binary_search(&ch) {
+            // add 2 and remove max_raw_score at the end,
+            // to keep the score interval of -max_raw_score..max_raw_score
+            char_scores[position] += 2;
+        }
+    }
+
+    // score of each lang.
+    let mut lang_scores = vec![0; Lang::all().len()];
+    let mut common_score: usize = 0;
+    // iterate over scored characters to compute language's scores.
+    for (position, char_score) in char_scores.into_iter().enumerate() {
+        if char_score > 0 {
+            let languages = &langs[position];
+            // if current character is common to all Languages, increment a common score
+            // instead of iterating over all Languages scores.
+            if languages.len() == all_langs.len() {
+                common_score += char_score;
+            } else {
+                for &lang in languages {
+                    lang_scores[lang as usize] += char_score;
+                }
+            }
+        }
+    }
+
+    // remap languages with theirs scores.
+    let mut raw_scores: Vec<(Lang, usize)> = all_langs
+        .iter()
+        .filter(|&&l| filter_list.is_allowed(l))
+        .map(|&l| {
+            let score = (lang_scores[l as usize] + common_score).saturating_sub(max_raw_score);
+            (l, score)
+        })
+        .collect();
+
+    raw_scores.sort_unstable_by_key(|(_, score)| Reverse(*score));
+
+    let mut normalized_scores = vec![];
+
+    for &(lang, raw_score) in raw_scores.iter() {
         let normalized_score = if raw_score == 0 {
             0.0
         } else {

--- a/src/alphabets/latin.rs
+++ b/src/alphabets/latin.rs
@@ -9,9 +9,7 @@ use crate::core::{FilterList, LowercaseText};
 use crate::{Lang, Script};
 
 /// Inverted map binding a character to a set of languages.
-pub static ALPHABET_LANG_MAP: Lazy<(Vec<char>, Vec<Vec<Lang>>)> = Lazy::new(|| {
-    let all_langs = Script::Latin.langs();
-
+pub fn get_alphabet_lang_map(all_langs: &[Lang]) -> (Vec<char>, Vec<Vec<Lang>>) {
     let mut map = HashMap::new();
     for lang in all_langs {
         let alphabet = get_lang_chars(&lang);
@@ -31,13 +29,14 @@ pub static ALPHABET_LANG_MAP: Lazy<(Vec<char>, Vec<Vec<Lang>>)> = Lazy::new(|| {
     }
 
     (chars, langs)
-});
+}
 
 pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList) -> RawOutcome {
     let all_langs = Script::Latin.langs();
     let all_chars_in_langs = get_all_chars_in_langs(all_langs);
 
-    let (chars, langs) = &*ALPHABET_LANG_MAP;
+    // let (chars, langs) = &*ALPHABET_LANG_MAP;
+    let (chars, langs) = get_alphabet_lang_map(all_langs);
 
     // score of each character.
     let mut char_scores = vec![0; chars.len()];

--- a/src/alphabets/latin.rs
+++ b/src/alphabets/latin.rs
@@ -1,113 +1,17 @@
-use std::cmp::Reverse;
-use std::collections::HashMap;
-
-use once_cell::sync::Lazy;
-
 use super::RawOutcome;
-use crate::alphabets::generic::{get_all_chars_in_langs, get_lang_chars, is_relevant_for_langs};
+use crate::alphabets::generic;
 use crate::core::{FilterList, LowercaseText};
-use crate::{Lang, Script};
-
-/// Inverted map binding a character to a set of languages.
-pub fn get_alphabet_lang_map(all_langs: &[Lang]) -> (Vec<char>, Vec<Vec<Lang>>) {
-    let mut map = HashMap::new();
-    for lang in all_langs {
-        let alphabet = get_lang_chars(&lang);
-        for c in alphabet.iter() {
-            let entry = map.entry(*c).or_insert_with(Vec::new);
-            entry.push(*lang);
-        }
-    }
-    let mut char_lang: Vec<_> = map.into_iter().collect();
-    char_lang.sort_unstable_by_key(|(c, _)| *c);
-
-    let mut chars = Vec::with_capacity(char_lang.len());
-    let mut langs = Vec::with_capacity(char_lang.len());
-    for (ch, languages) in char_lang {
-        chars.push(ch);
-        langs.push(languages);
-    }
-
-    (chars, langs)
-}
+use crate::Script;
 
 pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList) -> RawOutcome {
     let all_langs = Script::Latin.langs();
-    let all_chars_in_langs = get_all_chars_in_langs(all_langs);
-
-    // let (chars, langs) = &*ALPHABET_LANG_MAP;
-    let (chars, langs) = get_alphabet_lang_map(all_langs);
-
-    // score of each character.
-    let mut char_scores = vec![0; chars.len()];
-    let mut max_raw_score = 0;
-    // iterate over the text and scores characters.
-    for ch in text.chars() {
-        if !is_relevant_for_langs(&ch, &all_chars_in_langs) {
-            continue;
-        }
-
-        max_raw_score += 1;
-
-        if let Ok(position) = chars.binary_search(&ch) {
-            // add 2 and remove max_raw_score at the end,
-            // to keep the score interval of -max_raw_score..max_raw_score
-            char_scores[position] += 2;
-        }
-    }
-
-    // score of each lang.
-    let mut lang_scores = vec![0; Lang::all().len()];
-    let mut common_score: usize = 0;
-    // iterate over scored characters to compute language's scores.
-    for (position, char_score) in char_scores.into_iter().enumerate() {
-        if char_score > 0 {
-            let languages = &langs[position];
-            // if current character is common to all Languages, increment a common score
-            // instead of iterating over all Languages scores.
-            if languages.len() == all_langs.len() {
-                common_score += char_score;
-            } else {
-                for &lang in languages {
-                    lang_scores[lang as usize] += char_score;
-                }
-            }
-        }
-    }
-
-    // remap languages with theirs scores.
-    let mut raw_scores: Vec<(Lang, usize)> = all_langs
-        .iter()
-        .filter(|&&l| filter_list.is_allowed(l))
-        .map(|&l| {
-            let score = (lang_scores[l as usize] + common_score).saturating_sub(max_raw_score);
-            (l, score)
-        })
-        .collect();
-
-    raw_scores.sort_unstable_by_key(|(_, score)| Reverse(*score));
-
-    let mut normalized_scores = vec![];
-
-    for &(lang, raw_score) in raw_scores.iter() {
-        let normalized_score = if raw_score == 0 {
-            0.0
-        } else {
-            raw_score as f64 / max_raw_score as f64
-        };
-        normalized_scores.push((lang, normalized_score));
-    }
-
-    RawOutcome {
-        count: max_raw_score,
-        raw_scores,
-        scores: normalized_scores,
-    }
+    generic::alphabet_calculate_scores_generic(text, filter_list, all_langs)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Lang;
 
     #[test]
     fn test_alphabet_calculate_scores_against_harmaja_hauras() {

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -1,5 +1,6 @@
 mod cyrillic;
 pub(crate) mod detection;
+mod generic;
 mod latin;
 
 pub use detection::{detect, raw_detect};


### PR DESCRIPTION
#111 

it degrades performance a bit, mostly because we re-compute alphabet lang map instead of having static variable. It's probably possible to optimise

on my pc cargo bench went from 5kk to 8kk ns