### PR TITLE
Optimize alphabet cyrillic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 watch:
 	cargo watch -x test
+watch-doc:
+	cargo watch -s 'cargo doc --no-deps --all-features --document-private-items'
 doc:
-	cargo doc --no-deps  --all-features  --document-private-items  --open
+	cargo doc --no-deps --all-features --document-private-items --open
 bench:
 	cargo bench --all-features
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+watch:
+	cargo watch -x test
+doc:
+	cargo doc --no-deps  --all-features  --document-private-items  --open
+bench:
+	cargo bench --all-features
+test:
+	cargo test --all-features

--- a/README.md
+++ b/README.md
@@ -91,13 +91,12 @@ This function is a hyperbola and it looks like the following one:
 
 For more details, please check a blog article [Introduction to Rust Whatlang Library and Natural Language Identification Algorithms](https://www.greyblake.com/blog/2017-07-30-introduction-to-rust-whatlang-library-and-natural-language-identification-algorithms/).
 
-## Running benchmarks
+## Make tasks
 
-This is mostly useful to test performance optimizations.
-
-```
-cargo bench --all-features
-```
+* `make bench` - run performance benchmarks
+* `make doc` - generate and open doc
+* `make test` - run tests
+* `make watch` - watch changes and run tests
 
 ## Comparison with alternatives
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ For more details, please check a blog article [Introduction to Rust Whatlang Lib
 This is mostly useful to test performance optimizations.
 
 ```
-cargo bench
+cargo bench --all-features
 ```
 
 ## Comparison with alternatives

--- a/benches/example.rs
+++ b/benches/example.rs
@@ -1,10 +1,11 @@
 #[macro_use]
 extern crate bencher;
-extern crate serde_json;
-extern crate whatlang;
 
 use bencher::Bencher;
 use std::collections::HashMap;
+use whatlang::dev::{
+    alphabet_cyrillic_calculate_scores, alphabet_latin_calculate_scores, FilterList, LowercaseText,
+};
 use whatlang::{detect, detect_script};
 
 fn bench_detect(bench: &mut Bencher) {
@@ -29,5 +30,31 @@ fn bench_detect_script(bench: &mut Bencher) {
     })
 }
 
-benchmark_group!(benches, bench_detect, bench_detect_script);
+fn bench_alphabet_latin_calculate_scores(bench: &mut Bencher) {
+    let text = "Ich sehe auf die Uhr. Es ist kurz vor Mittag, und da heute Sonnabend ist, mache ich Schluß. Por ke lingvo internacia povu bone kaj regule progresadi kaj por ke ĝi havu plenan certecon, ke ĝi neniam disfalos kaj ia facilanima paŝo de ĝiaj amikoj estontaj ne detruos la laborojn de ĝiaj amikoj estintaj, - estas plej necesa antaŭ ĉio unu kondiĉo: la ezistado de klare difinita, neniam tuŝebla kaj neniam ŝangebla Fundamento de la lingvo.";
+    let lowercase_text = LowercaseText::new(text);
+    let filter = FilterList::All;
+
+    bench.iter(|| {
+        alphabet_latin_calculate_scores(&lowercase_text, &filter);
+    })
+}
+
+fn bench_alphabet_cyrillic_calculate_scores(bench: &mut Bencher) {
+    let text = "Творець есперанто Людвік Заменгоф назвав свою мову просто Lingvo internacia «міжнародна мова». Оскільки на той час у Європі популярною була інша штучна мова — волапюк, прихильники есперанто часто казали «мова доктора Есперанто». Згодом це формулювання скоротилося до «мова Есперанто», а врешті-решт залишилося одне лише слово «Esperanto», яке есперантською пишуть з великої літери, аби його можна було відрізнити від слова «людина, яка сподівається»";
+    let lowercase_text = LowercaseText::new(text);
+    let filter = FilterList::All;
+
+    bench.iter(|| {
+        alphabet_cyrillic_calculate_scores(&lowercase_text, &filter);
+    })
+}
+
+benchmark_group!(
+    benches,
+    bench_detect,
+    bench_detect_script,
+    bench_alphabet_latin_calculate_scores,
+    bench_alphabet_cyrillic_calculate_scores,
+);
 benchmark_main!(benches);

--- a/src/alphabets/common.rs
+++ b/src/alphabets/common.rs
@@ -1,8 +1,9 @@
+//! It's a hard-core optimized implementation of a relatively simple algorithm.
+//! The explanation of the algorithm can be found in the parent module [crate::alphabets].
+
 use std::cmp::Reverse;
 use std::collections::HashMap;
-
 use once_cell::sync::Lazy;
-
 use super::RawOutcome;
 use crate::core::{FilterList, LowercaseText};
 use crate::utils::is_stop_char;

--- a/src/alphabets/common.rs
+++ b/src/alphabets/common.rs
@@ -1,0 +1,106 @@
+use std::cmp::Reverse;
+use std::collections::HashMap;
+
+use once_cell::sync::Lazy;
+
+use super::RawOutcome;
+use crate::core::{FilterList, LowercaseText};
+use crate::utils::is_stop_char;
+use crate::{Lang, Script};
+
+/// Inverted map binding a character to a set of languages.
+pub fn build_inverted_map(alphabets: &[(Lang, &str)]) -> (Vec<char>, Vec<Vec<Lang>>) {
+    let mut map = HashMap::new();
+
+    for (lang, alphabet) in alphabets {
+        for c in alphabet.chars() {
+            let entry = map.entry(c).or_insert_with(Vec::new);
+            entry.push(*lang);
+        }
+    }
+
+    let mut char_lang: Vec<_> = map.into_iter().collect();
+
+    char_lang.sort_unstable_by_key(|(c, _)| *c);
+
+    let mut chars = Vec::with_capacity(char_lang.len());
+    let mut langs = Vec::with_capacity(char_lang.len());
+    for (ch, languages) in char_lang {
+        chars.push(ch);
+        langs.push(languages);
+    }
+
+    (chars, langs)
+}
+
+pub fn generic_alphabet_calculate_scores(
+    script: Script,
+    lang_map: &Lazy<(Vec<char>, Vec<Vec<Lang>>)>,
+    text: &LowercaseText,
+    filter_list: &FilterList,
+) -> RawOutcome {
+    let (chars, langs) = &**lang_map;
+    let script_langs = script.langs();
+
+    // score of each character.
+    let mut char_scores = vec![0; chars.len()];
+    let mut max_raw_score = 0;
+    // iterate over the text and scores characters.
+    for ch in text.chars() {
+        if is_stop_char(ch) {
+            continue;
+        }
+
+        max_raw_score += 1;
+
+        if let Ok(position) = chars.binary_search(&ch) {
+            // add 2 and remove max_raw_score at the end,
+            // to keep the score interval of -max_raw_score..max_raw_score
+            char_scores[position] += 2;
+        }
+    }
+
+    // score of each lang.
+    let mut lang_scores = vec![0; Lang::all().len()];
+    let mut common_score: usize = 0;
+    // iterate over scored characters to compute language's scores.
+    for (position, char_score) in char_scores.into_iter().enumerate() {
+        if char_score > 0 {
+            let languages = &langs[position];
+            // if current character is common to all Languages, increment a common score
+            // instead of iterating over all Languages scores.
+            if languages.len() == script_langs.len() {
+                common_score += char_score;
+            } else {
+                for &lang in languages {
+                    lang_scores[lang as usize] += char_score;
+                }
+            }
+        }
+    }
+
+    // remap languages with theirs scores.
+    let mut raw_scores: Vec<(Lang, usize)> = script_langs
+        .iter()
+        .filter(|&&l| filter_list.is_allowed(l))
+        .map(|&l| {
+            let score = (lang_scores[l as usize] + common_score).saturating_sub(max_raw_score);
+            (l, score)
+        })
+        .collect();
+
+    raw_scores.sort_unstable_by_key(|(_, score)| Reverse(*score));
+
+    let mut normalized_scores = vec![];
+
+    for &(lang, raw_score) in raw_scores.iter() {
+        let normalized_score = raw_score as f64 / max_raw_score as f64;
+        normalized_scores.push((lang, normalized_score));
+    }
+
+    RawOutcome {
+        count: max_raw_score,
+        raw_scores,
+        scores: normalized_scores,
+    }
+}

--- a/src/alphabets/common.rs
+++ b/src/alphabets/common.rs
@@ -1,13 +1,13 @@
 //! It's a hard-core optimized implementation of a relatively simple algorithm.
 //! The explanation of the algorithm can be found in the parent module [crate::alphabets].
 
-use std::cmp::Reverse;
-use std::collections::HashMap;
-use once_cell::sync::Lazy;
 use super::RawOutcome;
 use crate::core::{FilterList, LowercaseText};
 use crate::utils::is_stop_char;
 use crate::{Lang, Script};
+use once_cell::sync::Lazy;
+use std::cmp::Reverse;
+use std::collections::HashMap;
 
 /// Inverted map binding a character to a set of languages.
 pub fn build_inverted_map(alphabets: &[(Lang, &str)]) -> (Vec<char>, Vec<Vec<Lang>>) {

--- a/src/alphabets/latin.rs
+++ b/src/alphabets/latin.rs
@@ -1,11 +1,8 @@
-use std::cmp::Reverse;
-use std::collections::HashMap;
-
 use once_cell::sync::Lazy;
 
+use super::common::{build_inverted_map, generic_alphabet_calculate_scores};
 use super::RawOutcome;
 use crate::core::{FilterList, LowercaseText};
-use crate::utils::is_stop_char;
 use crate::{Lang, Script};
 
 const AFR: &str = "abcdefghijklmnopqrstuvwxyzáèéêëíîïóôúû";
@@ -86,100 +83,18 @@ const LATIN_ALPHABETS: &[(Lang, &str)] = &[
 ];
 
 /// Inverted map binding a character to a set of languages.
-pub static ALPHABET_LANG_MAP: Lazy<(Vec<char>, Vec<Vec<Lang>>)> = Lazy::new(|| {
-    let mut map = HashMap::new();
-
-    for (lang, alphabet) in LATIN_ALPHABETS {
-        for c in alphabet.chars() {
-            let entry = map.entry(c).or_insert_with(Vec::new);
-            entry.push(*lang);
-        }
-    }
-
-    let mut char_lang: Vec<_> = map.into_iter().collect();
-
-    char_lang.sort_unstable_by_key(|(c, _)| *c);
-
-    let mut chars = Vec::with_capacity(char_lang.len());
-    let mut langs = Vec::with_capacity(char_lang.len());
-    for (ch, languages) in char_lang {
-        chars.push(ch);
-        langs.push(languages);
-    }
-
-    (chars, langs)
-});
+pub static ALPHABET_LANG_MAP: Lazy<(Vec<char>, Vec<Vec<Lang>>)> =
+    Lazy::new(|| build_inverted_map(LATIN_ALPHABETS));
 
 pub fn alphabet_calculate_scores(text: &LowercaseText, filter_list: &FilterList) -> RawOutcome {
-    let (chars, langs) = &*ALPHABET_LANG_MAP;
-
-    // score of each character.
-    let mut char_scores = vec![0; chars.len()];
-    let mut max_raw_score = 0;
-    // iterate over the text and scores characters.
-    for ch in text.chars() {
-        if is_stop_char(ch) {
-            continue;
-        }
-
-        max_raw_score += 1;
-
-        if let Ok(position) = chars.binary_search(&ch) {
-            // add 2 and remove max_raw_score at the end,
-            // to keep the score interval of -max_raw_score..max_raw_score
-            char_scores[position] += 2;
-        }
-    }
-
-    // score of each lang.
-    let mut lang_scores = vec![0; Lang::all().len()];
-    let mut common_score: usize = 0;
-    // iterate over scored characters to compute language's scores.
-    for (position, char_score) in char_scores.into_iter().enumerate() {
-        if char_score > 0 {
-            let languages = &langs[position];
-            // if current character is common to all Languages, increment a common score
-            // instead of iterating over all Languages scores.
-            if languages.len() == LATIN_ALPHABETS.len() {
-                common_score += char_score;
-            } else {
-                for &lang in languages {
-                    lang_scores[lang as usize] += char_score;
-                }
-            }
-        }
-    }
-
-    // remap languages with theirs scores.
-    let mut raw_scores: Vec<(Lang, usize)> = Script::Latin
-        .langs()
-        .iter()
-        .filter(|&&l| filter_list.is_allowed(l))
-        .map(|&l| {
-            let score = (lang_scores[l as usize] + common_score).saturating_sub(max_raw_score);
-            (l, score)
-        })
-        .collect();
-
-    raw_scores.sort_unstable_by_key(|(_, score)| Reverse(*score));
-
-    let mut normalized_scores = vec![];
-
-    for &(lang, raw_score) in raw_scores.iter() {
-        let normalized_score = raw_score as f64 / max_raw_score as f64;
-        normalized_scores.push((lang, normalized_score));
-    }
-
-    RawOutcome {
-        count: max_raw_score,
-        raw_scores,
-        scores: normalized_scores,
-    }
+    generic_alphabet_calculate_scores(Script::Latin, &ALPHABET_LANG_MAP, text, filter_list)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::is_stop_char;
+    use crate::Script;
 
     // Old naive implementation, that is not very effective but easy to understand
     fn naive_alphabet_calculate_scores(

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -1,10 +1,41 @@
+//! Alphabet method is very inaccurate by itself to determine a language, but it supports
+//! other methods (trigrams) and allows to improve accuracy on very short texts.
+//!
+//! It's based on the fact, that some languages may use characters that are not present in others.
+//! (e.g. character `ö` is common for German or Finish texts, but not really expected to be
+//! seen in English or Spanish).
+//!
+//! ## Alogirthm
+//!
+//! * For every single character `c` in a lowecased text:
+//!   * If `c` is relevant for the script?
+//!     * count += 1
+//!     * for every language where `c` is a commonly used character
+//!       * raw_lang_score += 1
+//! * Normalize scores for every language:
+//!   * lang_score = raw_lang_score / count
+//!
+//! ## Pros and cons
+//!
+//! This algorithm is very simple and fast, but has also comes with some disadvantages:
+//! * Character frequencies are not respected (e.g. letter `O` has 7.16% occurrence rate in English and only
+//! 2.24% in German, but according to this alphabet model, both English and German would get +1
+//!   score for letter `O`).
+//! * It does not work always well: here are some examples:
+//!   * `Can you tell me where is Schönheitstraße?` - it's cleary an English sentence with a German
+//!   proper name `Schönheitstraße`, but the model gives 34 scores to German and only 30 to
+//!   English, because of the letters `ö` and `ß`, which are present in German, but not in English.
+//!   * `Façade` - is a valid English word. But English gets panished because of the untypical
+//!   character `ç` that was inherited from French.
+//!
+//! The generic (agnostic to a script) implementation and algorithm can be found in the [common] module.
+
 pub(crate) mod common;
 pub(crate) mod cyrillic;
 pub(crate) mod detection;
 pub(crate) mod latin;
 
 pub use detection::{detect, raw_detect};
-
 use crate::Lang;
 
 #[derive(Debug)]

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod common;
 pub(crate) mod cyrillic;
 pub(crate) mod detection;
 pub(crate) mod latin;

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -35,8 +35,8 @@ pub(crate) mod cyrillic;
 pub(crate) mod detection;
 pub(crate) mod latin;
 
-pub use detection::{detect, raw_detect};
 use crate::Lang;
+pub use detection::{detect, raw_detect};
 
 #[derive(Debug)]
 pub struct RawOutcome {

--- a/src/alphabets/mod.rs
+++ b/src/alphabets/mod.rs
@@ -1,6 +1,6 @@
-mod cyrillic;
+pub(crate) mod cyrillic;
 pub(crate) mod detection;
-mod latin;
+pub(crate) mod latin;
 
 pub use detection::{detect, raw_detect};
 

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -9,9 +9,13 @@ pub use crate::lang::Lang;
 pub use crate::scripts::{detect_script, raw_detect_script, RawScriptInfo, Script};
 pub use crate::trigrams::{raw_detect as trigrams_raw_detect, RawOutcome as RawTrigramsInfo};
 
+pub use crate::alphabets::cyrillic::alphabet_calculate_scores as alphabet_cyrillic_calculate_scores;
+pub use crate::alphabets::latin::alphabet_calculate_scores as alphabet_latin_calculate_scores;
+pub use crate::core::{FilterList, LowercaseText};
+
 // private imports
 use crate::core::detect::detect_lang_base_on_mandarin_script;
-use crate::core::{FilterList, Query};
+use crate::core::Query;
 use crate::scripts::grouping::ScriptLangGroup;
 
 #[derive(Debug)]

--- a/src/scripts/chars.rs
+++ b/src/scripts/chars.rs
@@ -1,0 +1,282 @@
+pub(crate) fn is_cyrillic(ch: char) -> bool {
+    matches!(ch,
+        '\u{0400}'..='\u{0484}'
+        | '\u{0487}'..='\u{052F}'
+        | '\u{2DE0}'..='\u{2DFF}'
+        | '\u{A640}'..='\u{A69D}'
+        | '\u{1D2B}'
+        | '\u{1D78}'
+        | '\u{A69F}'
+    )
+}
+
+// https://en.wikipedia.org/wiki/Latin_script_in_Unicode
+pub(crate) fn is_latin(ch: char) -> bool {
+    matches!(ch,
+        'a'..='z'
+        | 'A'..='Z'
+        | '\u{0080}'..='\u{00FF}'
+        | '\u{0100}'..='\u{017F}'
+        | '\u{0180}'..='\u{024F}'
+        | '\u{0250}'..='\u{02AF}'
+        | '\u{1D00}'..='\u{1D7F}'
+        | '\u{1D80}'..='\u{1DBF}'
+        | '\u{1E00}'..='\u{1EFF}'
+        | '\u{2100}'..='\u{214F}'
+        | '\u{2C60}'..='\u{2C7F}'
+        | '\u{A720}'..='\u{A7FF}'
+        | '\u{AB30}'..='\u{AB6F}'
+    )
+}
+
+// Based on https://en.wikipedia.org/wiki/Arabic_script_in_Unicode
+pub(crate) fn is_arabic(ch: char) -> bool {
+    matches!(ch,
+        '\u{0600}'..='\u{06FF}'
+        | '\u{0750}'..='\u{07FF}'
+        | '\u{08A0}'..='\u{08FF}'
+        | '\u{FB50}'..='\u{FDFF}'
+        | '\u{FE70}'..='\u{FEFF}'
+        | '\u{10E60}'..='\u{10E7F}'
+        | '\u{1EE00}'..='\u{1EEFF}'
+    )
+}
+
+// Based on https://en.wikipedia.org/wiki/Devanagari#Unicode
+pub(crate) fn is_devanagari(ch: char) -> bool {
+    matches!(ch, '\u{0900}'..='\u{097F}' | '\u{A8E0}'..='\u{A8FF}' | '\u{1CD0}'..='\u{1CFF}')
+}
+
+// Based on https://www.key-shortcut.com/en/writing-systems/ethiopian-script/
+pub(crate) fn is_ethiopic(ch: char) -> bool {
+    matches!(ch, '\u{1200}'..='\u{139F}' | '\u{2D80}'..='\u{2DDF}' | '\u{AB00}'..='\u{AB2F}')
+}
+
+// Based on https://en.wikipedia.org/wiki/Hebrew_(Unicode_block)
+pub(crate) fn is_hebrew(ch: char) -> bool {
+    matches!(ch, '\u{0590}'..='\u{05FF}')
+}
+
+pub(crate) fn is_georgian(ch: char) -> bool {
+    matches!(ch, '\u{10A0}'..='\u{10FF}')
+}
+
+pub(crate) fn is_mandarin(ch: char) -> bool {
+    matches!(ch,
+        '\u{2E80}'..='\u{2E99}'
+        | '\u{2E9B}'..='\u{2EF3}'
+        | '\u{2F00}'..='\u{2FD5}'
+        | '\u{3005}'
+        | '\u{3007}'
+        | '\u{3021}'..='\u{3029}'
+        | '\u{3038}'..='\u{303B}'
+        | '\u{3400}'..='\u{4DB5}'
+        | '\u{4E00}'..='\u{9FCC}'
+        | '\u{F900}'..='\u{FA6D}'
+        | '\u{FA70}'..='\u{FAD9}'
+    )
+}
+
+pub(crate) fn is_bengali(ch: char) -> bool {
+    matches!(ch, '\u{0980}'..='\u{09FF}')
+}
+
+pub(crate) fn is_hiragana(ch: char) -> bool {
+    matches!(ch, '\u{3040}'..='\u{309F}')
+}
+
+pub(crate) fn is_katakana(ch: char) -> bool {
+    matches!(ch, '\u{30A0}'..='\u{30FF}')
+}
+
+// Hangul is Korean Alphabet. Unicode ranges are taken from: https://en.wikipedia.org/wiki/Hangul
+pub(crate) fn is_hangul(ch: char) -> bool {
+    matches!(ch,
+        '\u{AC00}'..='\u{D7AF}'
+        | '\u{1100}'..='\u{11FF}'
+        | '\u{3130}'..='\u{318F}'
+        | '\u{3200}'..='\u{32FF}'
+        | '\u{A960}'..='\u{A97F}'
+        | '\u{D7B0}'..='\u{D7FF}'
+        | '\u{FF00}'..='\u{FFEF}'
+    )
+}
+
+// Taken from: https://en.wikipedia.org/wiki/Greek_and_Coptic
+pub(crate) fn is_greek(ch: char) -> bool {
+    matches!(ch, '\u{0370}'..='\u{03FF}')
+}
+
+// Based on: https://en.wikipedia.org/wiki/Kannada_(Unicode_block)
+pub(crate) fn is_kannada(ch: char) -> bool {
+    matches!(ch, '\u{0C80}'..='\u{0CFF}')
+}
+
+// Based on: https://en.wikipedia.org/wiki/Tamil_(Unicode_block)
+pub(crate) fn is_tamil(ch: char) -> bool {
+    matches!(ch, '\u{0B80}'..='\u{0BFF}')
+}
+
+// Based on: https://en.wikipedia.org/wiki/Thai_(Unicode_block)
+pub(crate) fn is_thai(ch: char) -> bool {
+    matches!(ch, '\u{0E00}'..='\u{0E7F}')
+}
+
+// Based on: https://en.wikipedia.org/wiki/Gujarati_(Unicode_block)
+pub(crate) fn is_gujarati(ch: char) -> bool {
+    matches!(ch, '\u{0A80}'..='\u{0AFF}')
+}
+
+// Gurmukhi is the script for Punjabi language.
+// Based on: https://en.wikipedia.org/wiki/Gurmukhi_(Unicode_block)
+pub(crate) fn is_gurmukhi(ch: char) -> bool {
+    matches!(ch, '\u{0A00}'..='\u{0A7F}')
+}
+
+pub(crate) fn is_telugu(ch: char) -> bool {
+    matches!(ch, '\u{0C00}'..='\u{0C7F}')
+}
+
+// Based on: https://en.wikipedia.org/wiki/Malayalam_(Unicode_block)
+pub(crate) fn is_malayalam(ch: char) -> bool {
+    matches!(ch, '\u{0D00}'..='\u{0D7F}')
+}
+
+// Based on: https://en.wikipedia.org/wiki/Malayalam_(Unicode_block)
+pub(crate) fn is_oriya(ch: char) -> bool {
+    matches!(ch, '\u{0B00}'..='\u{0B7F}')
+}
+
+// Based on: https://en.wikipedia.org/wiki/Myanmar_(Unicode_block)
+pub(crate) fn is_myanmar(ch: char) -> bool {
+    matches!(ch, '\u{1000}'..='\u{109F}')
+}
+
+// Based on: https://en.wikipedia.org/wiki/Sinhala_(Unicode_block)
+pub(crate) fn is_sinhala(ch: char) -> bool {
+    matches!(ch, '\u{0D80}'..='\u{0DFF}')
+}
+
+// Based on: https://en.wikipedia.org/wiki/Khmer_alphabet
+pub(crate) fn is_khmer(ch: char) -> bool {
+    matches!(ch, '\u{1780}'..='\u{17FF}' | '\u{19E0}'..='\u{19FF}')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_latin() {
+        assert_eq!(is_latin('z'), true);
+        assert_eq!(is_latin('A'), true);
+        assert_eq!(is_latin('č'), true);
+        assert_eq!(is_latin('š'), true);
+        assert_eq!(is_latin('Ĵ'), true);
+
+        assert_eq!(is_latin('ж'), false);
+    }
+
+    #[test]
+    fn test_is_cyrillic() {
+        assert_eq!(is_cyrillic('а'), true);
+        assert_eq!(is_cyrillic('Я'), true);
+        assert_eq!(is_cyrillic('Ґ'), true);
+        assert_eq!(is_cyrillic('ї'), true);
+        assert_eq!(is_cyrillic('Ꙕ'), true);
+
+        assert_eq!(is_cyrillic('L'), false);
+    }
+
+    #[test]
+    fn test_is_ethiopic() {
+        assert_eq!(is_ethiopic('ፚ'), true);
+        assert_eq!(is_ethiopic('ᎀ'), true);
+
+        assert_eq!(is_ethiopic('а'), false);
+        assert_eq!(is_ethiopic('L'), false);
+    }
+
+    #[test]
+    fn test_is_georgian() {
+        assert_eq!(is_georgian('რ'), true);
+        assert_eq!(is_georgian('ж'), false);
+    }
+
+    #[test]
+    fn test_is_bengali() {
+        assert_eq!(is_bengali('ই'), true);
+        assert_eq!(is_bengali('z'), false);
+    }
+
+    #[test]
+    fn test_is_katakana() {
+        assert_eq!(is_katakana('カ'), true);
+        assert_eq!(is_katakana('f'), false);
+    }
+
+    #[test]
+    fn test_is_hiragana() {
+        assert_eq!(is_hiragana('ひ'), true);
+        assert_eq!(is_hiragana('a'), false);
+    }
+
+    #[test]
+    fn test_is_hangul() {
+        assert_eq!(is_hangul('ᄁ'), true);
+        assert_eq!(is_hangul('t'), false);
+    }
+
+    #[test]
+    fn test_is_greek() {
+        assert_eq!(is_greek('φ'), true);
+        assert_eq!(is_greek('ф'), false);
+    }
+
+    #[test]
+    fn test_is_kannada() {
+        assert_eq!(is_kannada('ಡ'), true);
+        assert_eq!(is_kannada('S'), false);
+    }
+
+    #[test]
+    fn test_is_tamil() {
+        assert_eq!(is_tamil('ஐ'), true);
+        assert_eq!(is_tamil('Ж'), false);
+    }
+
+    #[test]
+    fn test_is_thai() {
+        assert_eq!(is_thai('ก'), true);
+        assert_eq!(is_thai('๛'), true);
+        assert_eq!(is_thai('Ж'), false);
+    }
+
+    #[test]
+    fn test_is_gujarati() {
+        assert_eq!(is_gujarati('ઁ'), true);
+        assert_eq!(is_gujarati('૱'), true);
+        assert_eq!(is_gujarati('Ж'), false);
+    }
+
+    #[test]
+    fn test_is_gurmukhi() {
+        assert_eq!(is_gurmukhi('ਁ'), true);
+        assert_eq!(is_gurmukhi('ੴ'), true);
+        assert_eq!(is_gurmukhi('Ж'), false);
+    }
+
+    #[test]
+    fn test_is_telugu() {
+        assert_eq!(is_telugu('ఁ'), true);
+        assert_eq!(is_telugu('౿'), true);
+        assert_eq!(is_telugu('Ж'), false);
+    }
+
+    #[test]
+    fn test_is_oriya() {
+        assert_eq!(is_oriya('ଐ'), true);
+        assert_eq!(is_oriya('୷'), true);
+        assert_eq!(is_oriya('౿'), false);
+    }
+}

--- a/src/scripts/detect.rs
+++ b/src/scripts/detect.rs
@@ -1,5 +1,6 @@
 use std::cmp::Reverse;
 
+use super::chars;
 use super::script::Script;
 use crate::utils::is_stop_char;
 
@@ -54,30 +55,30 @@ impl RawScriptInfo {
 
 pub fn raw_detect_script(text: &str) -> RawScriptInfo {
     let mut script_counters: [ScriptCounter; 24] = [
-        (Script::Latin, is_latin, 0),
-        (Script::Cyrillic, is_cyrillic, 0),
-        (Script::Arabic, is_arabic, 0),
-        (Script::Mandarin, is_mandarin, 0),
-        (Script::Devanagari, is_devanagari, 0),
-        (Script::Hebrew, is_hebrew, 0),
-        (Script::Ethiopic, is_ethiopic, 0),
-        (Script::Georgian, is_georgian, 0),
-        (Script::Bengali, is_bengali, 0),
-        (Script::Hangul, is_hangul, 0),
-        (Script::Hiragana, is_hiragana, 0),
-        (Script::Katakana, is_katakana, 0),
-        (Script::Greek, is_greek, 0),
-        (Script::Kannada, is_kannada, 0),
-        (Script::Tamil, is_tamil, 0),
-        (Script::Thai, is_thai, 0),
-        (Script::Gujarati, is_gujarati, 0),
-        (Script::Gurmukhi, is_gurmukhi, 0),
-        (Script::Telugu, is_telugu, 0),
-        (Script::Malayalam, is_malayalam, 0),
-        (Script::Oriya, is_oriya, 0),
-        (Script::Myanmar, is_myanmar, 0),
-        (Script::Sinhala, is_sinhala, 0),
-        (Script::Khmer, is_khmer, 0),
+        (Script::Latin, chars::is_latin, 0),
+        (Script::Cyrillic, chars::is_cyrillic, 0),
+        (Script::Arabic, chars::is_arabic, 0),
+        (Script::Mandarin, chars::is_mandarin, 0),
+        (Script::Devanagari, chars::is_devanagari, 0),
+        (Script::Hebrew, chars::is_hebrew, 0),
+        (Script::Ethiopic, chars::is_ethiopic, 0),
+        (Script::Georgian, chars::is_georgian, 0),
+        (Script::Bengali, chars::is_bengali, 0),
+        (Script::Hangul, chars::is_hangul, 0),
+        (Script::Hiragana, chars::is_hiragana, 0),
+        (Script::Katakana, chars::is_katakana, 0),
+        (Script::Greek, chars::is_greek, 0),
+        (Script::Kannada, chars::is_kannada, 0),
+        (Script::Tamil, chars::is_tamil, 0),
+        (Script::Thai, chars::is_thai, 0),
+        (Script::Gujarati, chars::is_gujarati, 0),
+        (Script::Gurmukhi, chars::is_gurmukhi, 0),
+        (Script::Telugu, chars::is_telugu, 0),
+        (Script::Malayalam, chars::is_malayalam, 0),
+        (Script::Oriya, chars::is_oriya, 0),
+        (Script::Myanmar, chars::is_myanmar, 0),
+        (Script::Sinhala, chars::is_sinhala, 0),
+        (Script::Khmer, chars::is_khmer, 0),
     ];
 
     for ch in text.chars() {
@@ -117,170 +118,6 @@ pub fn raw_detect_script(text: &str) -> RawScriptInfo {
         .collect();
 
     RawScriptInfo::new(counters)
-}
-
-fn is_cyrillic(ch: char) -> bool {
-    matches!(ch,
-        '\u{0400}'..='\u{0484}'
-        | '\u{0487}'..='\u{052F}'
-        | '\u{2DE0}'..='\u{2DFF}'
-        | '\u{A640}'..='\u{A69D}'
-        | '\u{1D2B}'
-        | '\u{1D78}'
-        | '\u{A69F}'
-    )
-}
-
-// https://en.wikipedia.org/wiki/Latin_script_in_Unicode
-fn is_latin(ch: char) -> bool {
-    matches!(ch,
-        'a'..='z'
-        | 'A'..='Z'
-        | '\u{0080}'..='\u{00FF}'
-        | '\u{0100}'..='\u{017F}'
-        | '\u{0180}'..='\u{024F}'
-        | '\u{0250}'..='\u{02AF}'
-        | '\u{1D00}'..='\u{1D7F}'
-        | '\u{1D80}'..='\u{1DBF}'
-        | '\u{1E00}'..='\u{1EFF}'
-        | '\u{2100}'..='\u{214F}'
-        | '\u{2C60}'..='\u{2C7F}'
-        | '\u{A720}'..='\u{A7FF}'
-        | '\u{AB30}'..='\u{AB6F}'
-    )
-}
-
-// Based on https://en.wikipedia.org/wiki/Arabic_script_in_Unicode
-fn is_arabic(ch: char) -> bool {
-    matches!(ch,
-        '\u{0600}'..='\u{06FF}'
-        | '\u{0750}'..='\u{07FF}'
-        | '\u{08A0}'..='\u{08FF}'
-        | '\u{FB50}'..='\u{FDFF}'
-        | '\u{FE70}'..='\u{FEFF}'
-        | '\u{10E60}'..='\u{10E7F}'
-        | '\u{1EE00}'..='\u{1EEFF}'
-    )
-}
-
-// Based on https://en.wikipedia.org/wiki/Devanagari#Unicode
-fn is_devanagari(ch: char) -> bool {
-    matches!(ch, '\u{0900}'..='\u{097F}' | '\u{A8E0}'..='\u{A8FF}' | '\u{1CD0}'..='\u{1CFF}')
-}
-
-// Based on https://www.key-shortcut.com/en/writing-systems/ethiopian-script/
-fn is_ethiopic(ch: char) -> bool {
-    matches!(ch, '\u{1200}'..='\u{139F}' | '\u{2D80}'..='\u{2DDF}' | '\u{AB00}'..='\u{AB2F}')
-}
-
-// Based on https://en.wikipedia.org/wiki/Hebrew_(Unicode_block)
-fn is_hebrew(ch: char) -> bool {
-    matches!(ch, '\u{0590}'..='\u{05FF}')
-}
-
-fn is_georgian(ch: char) -> bool {
-    matches!(ch, '\u{10A0}'..='\u{10FF}')
-}
-
-fn is_mandarin(ch: char) -> bool {
-    matches!(ch,
-        '\u{2E80}'..='\u{2E99}'
-        | '\u{2E9B}'..='\u{2EF3}'
-        | '\u{2F00}'..='\u{2FD5}'
-        | '\u{3005}'
-        | '\u{3007}'
-        | '\u{3021}'..='\u{3029}'
-        | '\u{3038}'..='\u{303B}'
-        | '\u{3400}'..='\u{4DB5}'
-        | '\u{4E00}'..='\u{9FCC}'
-        | '\u{F900}'..='\u{FA6D}'
-        | '\u{FA70}'..='\u{FAD9}'
-    )
-}
-
-fn is_bengali(ch: char) -> bool {
-    matches!(ch, '\u{0980}'..='\u{09FF}')
-}
-
-fn is_hiragana(ch: char) -> bool {
-    matches!(ch, '\u{3040}'..='\u{309F}')
-}
-
-fn is_katakana(ch: char) -> bool {
-    matches!(ch, '\u{30A0}'..='\u{30FF}')
-}
-
-// Hangul is Korean Alphabet. Unicode ranges are taken from: https://en.wikipedia.org/wiki/Hangul
-fn is_hangul(ch: char) -> bool {
-    matches!(ch,
-        '\u{AC00}'..='\u{D7AF}'
-        | '\u{1100}'..='\u{11FF}'
-        | '\u{3130}'..='\u{318F}'
-        | '\u{3200}'..='\u{32FF}'
-        | '\u{A960}'..='\u{A97F}'
-        | '\u{D7B0}'..='\u{D7FF}'
-        | '\u{FF00}'..='\u{FFEF}'
-    )
-}
-
-// Taken from: https://en.wikipedia.org/wiki/Greek_and_Coptic
-fn is_greek(ch: char) -> bool {
-    matches!(ch, '\u{0370}'..='\u{03FF}')
-}
-
-// Based on: https://en.wikipedia.org/wiki/Kannada_(Unicode_block)
-fn is_kannada(ch: char) -> bool {
-    matches!(ch, '\u{0C80}'..='\u{0CFF}')
-}
-
-// Based on: https://en.wikipedia.org/wiki/Tamil_(Unicode_block)
-fn is_tamil(ch: char) -> bool {
-    matches!(ch, '\u{0B80}'..='\u{0BFF}')
-}
-
-// Based on: https://en.wikipedia.org/wiki/Thai_(Unicode_block)
-fn is_thai(ch: char) -> bool {
-    matches!(ch, '\u{0E00}'..='\u{0E7F}')
-}
-
-// Based on: https://en.wikipedia.org/wiki/Gujarati_(Unicode_block)
-fn is_gujarati(ch: char) -> bool {
-    matches!(ch, '\u{0A80}'..='\u{0AFF}')
-}
-
-// Gurmukhi is the script for Punjabi language.
-// Based on: https://en.wikipedia.org/wiki/Gurmukhi_(Unicode_block)
-fn is_gurmukhi(ch: char) -> bool {
-    matches!(ch, '\u{0A00}'..='\u{0A7F}')
-}
-
-fn is_telugu(ch: char) -> bool {
-    matches!(ch, '\u{0C00}'..='\u{0C7F}')
-}
-
-// Based on: https://en.wikipedia.org/wiki/Malayalam_(Unicode_block)
-fn is_malayalam(ch: char) -> bool {
-    matches!(ch, '\u{0D00}'..='\u{0D7F}')
-}
-
-// Based on: https://en.wikipedia.org/wiki/Malayalam_(Unicode_block)
-fn is_oriya(ch: char) -> bool {
-    matches!(ch, '\u{0B00}'..='\u{0B7F}')
-}
-
-// Based on: https://en.wikipedia.org/wiki/Myanmar_(Unicode_block)
-fn is_myanmar(ch: char) -> bool {
-    matches!(ch, '\u{1000}'..='\u{109F}')
-}
-
-// Based on: https://en.wikipedia.org/wiki/Sinhala_(Unicode_block)
-fn is_sinhala(ch: char) -> bool {
-    matches!(ch, '\u{0D80}'..='\u{0DFF}')
-}
-
-// Based on: https://en.wikipedia.org/wiki/Khmer_alphabet
-fn is_khmer(ch: char) -> bool {
-    matches!(ch, '\u{1780}'..='\u{17FF}' | '\u{19E0}'..='\u{19FF}')
 }
 
 #[cfg(test)]
@@ -334,119 +171,5 @@ mod tests {
             detect_script("Russian word любовь means love."),
             Some(Script::Latin)
         );
-    }
-
-    #[test]
-    fn test_is_latin() {
-        assert_eq!(is_latin('z'), true);
-        assert_eq!(is_latin('A'), true);
-        assert_eq!(is_latin('č'), true);
-        assert_eq!(is_latin('š'), true);
-        assert_eq!(is_latin('Ĵ'), true);
-
-        assert_eq!(is_latin('ж'), false);
-    }
-
-    #[test]
-    fn test_is_cyrillic() {
-        assert_eq!(is_cyrillic('а'), true);
-        assert_eq!(is_cyrillic('Я'), true);
-        assert_eq!(is_cyrillic('Ґ'), true);
-        assert_eq!(is_cyrillic('ї'), true);
-        assert_eq!(is_cyrillic('Ꙕ'), true);
-
-        assert_eq!(is_cyrillic('L'), false);
-    }
-
-    #[test]
-    fn test_is_ethiopic() {
-        assert_eq!(is_ethiopic('ፚ'), true);
-        assert_eq!(is_ethiopic('ᎀ'), true);
-
-        assert_eq!(is_ethiopic('а'), false);
-        assert_eq!(is_ethiopic('L'), false);
-    }
-
-    #[test]
-    fn test_is_georgian() {
-        assert_eq!(is_georgian('რ'), true);
-        assert_eq!(is_georgian('ж'), false);
-    }
-
-    #[test]
-    fn test_is_bengali() {
-        assert_eq!(is_bengali('ই'), true);
-        assert_eq!(is_bengali('z'), false);
-    }
-
-    #[test]
-    fn test_is_katakana() {
-        assert_eq!(is_katakana('カ'), true);
-        assert_eq!(is_katakana('f'), false);
-    }
-
-    #[test]
-    fn test_is_hiragana() {
-        assert_eq!(is_hiragana('ひ'), true);
-        assert_eq!(is_hiragana('a'), false);
-    }
-
-    #[test]
-    fn test_is_hangul() {
-        assert_eq!(is_hangul('ᄁ'), true);
-        assert_eq!(is_hangul('t'), false);
-    }
-
-    #[test]
-    fn test_is_greek() {
-        assert_eq!(is_greek('φ'), true);
-        assert_eq!(is_greek('ф'), false);
-    }
-
-    #[test]
-    fn test_is_kannada() {
-        assert_eq!(is_kannada('ಡ'), true);
-        assert_eq!(is_kannada('S'), false);
-    }
-
-    #[test]
-    fn test_is_tamil() {
-        assert_eq!(is_tamil('ஐ'), true);
-        assert_eq!(is_tamil('Ж'), false);
-    }
-
-    #[test]
-    fn test_is_thai() {
-        assert_eq!(is_thai('ก'), true);
-        assert_eq!(is_thai('๛'), true);
-        assert_eq!(is_thai('Ж'), false);
-    }
-
-    #[test]
-    fn test_is_gujarati() {
-        assert_eq!(is_gujarati('ઁ'), true);
-        assert_eq!(is_gujarati('૱'), true);
-        assert_eq!(is_gujarati('Ж'), false);
-    }
-
-    #[test]
-    fn test_is_gurmukhi() {
-        assert_eq!(is_gurmukhi('ਁ'), true);
-        assert_eq!(is_gurmukhi('ੴ'), true);
-        assert_eq!(is_gurmukhi('Ж'), false);
-    }
-
-    #[test]
-    fn test_is_telugu() {
-        assert_eq!(is_telugu('ఁ'), true);
-        assert_eq!(is_telugu('౿'), true);
-        assert_eq!(is_telugu('Ж'), false);
-    }
-
-    #[test]
-    fn test_is_oriya() {
-        assert_eq!(is_oriya('ଐ'), true);
-        assert_eq!(is_oriya('୷'), true);
-        assert_eq!(is_oriya('౿'), false);
     }
 }

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod chars;
 mod detect;
 pub(crate) mod grouping;
 mod lang_mapping;


### PR DESCRIPTION
Before

```
test bench_alphabet_cyrillic_calculate_scores ... bench:      91,479 ns/iter (+/- 6,833)
test bench_alphabet_latin_calculate_scores    ... bench:       2,459 ns/iter (+/- 204)
test bench_detect                             ... bench:   4,733,183 ns/iter (+/- 269,322)
test bench_detect_script                      ... bench:     110,753 ns/iter (+/- 15,023)

```

After

```
test bench_alphabet_cyrillic_calculate_scores ... bench:       2,176 ns/iter (+/- 449)
test bench_alphabet_latin_calculate_scores    ... bench:       2,562 ns/iter (+/- 610)
test bench_detect                             ... bench:   4,429,384 ns/iter (+/- 203,850)
test bench_detect_script                      ... bench:     112,496 ns/iter (+/- 14,456)

```