### PR TITLE
Replace hashbrown::HashMap with std::collections::HashMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ include = [
 ]
 
 [dependencies]
-hashbrown = "0.12.0"
+# hashbrown = "0.12.0"
 once_cell = "1.10.0"
 enum-map = { version = "2", optional = true }
 

--- a/src/trigrams/detection.rs
+++ b/src/trigrams/detection.rs
@@ -1,4 +1,4 @@
-use hashbrown::HashMap;
+use std::collections::HashMap;
 
 use super::utils::{get_trigrams_with_positions, TrigramsWithPositions};
 use super::{LangProfile, LangProfileList};

--- a/src/trigrams/utils.rs
+++ b/src/trigrams/utils.rs
@@ -1,4 +1,4 @@
-use hashbrown::HashMap;
+use std::collections::HashMap;
 
 use super::Trigram;
 use super::TEXT_TRIGRAMS_SIZE;


### PR DESCRIPTION
This a code changes for https://github.com/greyblake/whatlang-rs/issues/98

## Benchmarks


### hashbrown::HashMap

```
running 4 tests
test bench_alphabet_cyrillic_calculate_scores ... bench:       2,157 ns/iter (+/- 23)
test bench_alphabet_latin_calculate_scores    ... bench:       2,431 ns/iter (+/- 80)
test bench_detect                             ... bench:   4,254,212 ns/iter (+/- 108,815)
test bench_detect_script                      ... bench:     107,647 ns/iter (+/- 2,975)
```

### std::collections::HashMap

```
test bench_alphabet_cyrillic_calculate_scores ... bench:       1,937 ns/iter (+/- 372)
test bench_alphabet_latin_calculate_scores    ... bench:       2,206 ns/iter (+/- 81)
test bench_detect                             ... bench:   9,446,431 ns/iter (+/- 147,967)
test bench_detect_script                      ... bench:     111,002 ns/iter (+/- 4,825)
```

`detect()` becomes 2x slower when with `std::collections::HashMap`.