### PR TITLE
Impl Hash for Script

### DIFF
--- a/src/scripts/script.rs
+++ b/src/scripts/script.rs
@@ -8,7 +8,7 @@ use crate::Lang;
 /// Represents a writing system (Latin, Cyrillic, Arabic, etc).
 #[cfg_attr(feature = "enum-map", derive(::enum_map::Enum))]
 #[cfg_attr(feature = "arbitrary", derive(::arbitrary::Arbitrary))]
-#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
 pub enum Script {
     // Keep this in alphabetic order (for C bindings)
     Arabic,


### PR DESCRIPTION
Simply implements Hash for the Script type, as per the [C-COMMON-TRAITS API guideline](https://rust-lang.github.io/api-guidelines/interoperability.html#types-eagerly-implement-common-traits-c-common-traits).

There are some other types in this crate that doesn't follow this guideline either. `whatlang::Info` doesn't implement some common traits either, as an example.