### PR TITLE
`raw_detect` perf tweaks

### DIFF
--- a/src/combined/mod.rs
+++ b/src/combined/mod.rs
@@ -33,25 +33,25 @@ pub fn detect(iquery: &InternalQuery) -> Option<Info> {
 
 // TODO: optimize!
 pub fn raw_detect(iquery: &InternalQuery) -> RawOutcome {
-    let alphabet_raw_outcome = alphabets::raw_detect(iquery);
-    let trigram_raw_outcome = trigrams::raw_detect(iquery);
+    let alphabet_raw_outcome: alphabets::RawOutcome = alphabets::raw_detect(iquery);
+    let trigram_raw_outcome: trigrams::RawOutcome = trigrams::raw_detect(iquery);
 
-    let alphabet_scores = &alphabet_raw_outcome.scores;
-    let trigram_scores = &trigram_raw_outcome.scores;
+    let alphabet_scores: &Vec<(Lang, f64)> = &alphabet_raw_outcome.scores;
+    let trigram_scores: &Vec<(Lang, f64)> = &trigram_raw_outcome.scores;
 
     let mut all_langs: Vec<Lang> = alphabet_scores.iter().map(|x| x.0).collect();
-    trigram_scores.iter().for_each(|(lang, _)| {
+    for (lang, _) in trigram_scores.iter() {
         if !all_langs.contains(lang) {
             all_langs.push(*lang);
         }
-    });
+    }
 
     let count = alphabet_raw_outcome.count;
 
     let alphabet_weight = calc_alphabet_weight(count);
     let trigram_weight = 1.0 - alphabet_weight;
 
-    let mut scores = vec![];
+    let mut scores = Vec::with_capacity(alphabet_scores.len() + trigram_scores.len());
 
     for lang in all_langs {
         let a: f64 = alphabet_scores

--- a/src/combined/mod.rs
+++ b/src/combined/mod.rs
@@ -51,7 +51,7 @@ pub fn raw_detect(iquery: &InternalQuery) -> RawOutcome {
     let alphabet_weight = calc_alphabet_weight(count);
     let trigram_weight = 1.0 - alphabet_weight;
 
-    let mut scores = Vec::with_capacity(alphabet_scores.len() + trigram_scores.len());
+    let mut scores = Vec::with_capacity(all_langs.len());
 
     for lang in all_langs {
         let a: f64 = alphabet_scores


### PR DESCRIPTION
- applied clippy::needless_for_each lint (see https://rust-lang.github.io/rust-clippy/master/index.html#needless_for_each)
- declare scores vec with_capacity to minimize allocs

Before:
```
running 4 tests
test bench_alphabet_cyrillic_calculate_scores ... bench:       1,923 ns/iter (+/- 60)
test bench_alphabet_latin_calculate_scores    ... bench:       2,706 ns/iter (+/- 151)
test bench_detect                             ... bench:   4,219,612 ns/iter (+/- 129,220)
test bench_detect_script                      ... bench:      73,365 ns/iter (+/- 3,556)
```

After tweaks:
```
running 4 tests
test bench_alphabet_cyrillic_calculate_scores ... bench:       1,917 ns/iter (+/- 68)
test bench_alphabet_latin_calculate_scores    ... bench:       2,748 ns/iter (+/- 98)
test bench_detect                             ... bench:   4,188,685 ns/iter (+/- 157,631)
test bench_detect_script                      ... bench:      69,409 ns/iter (+/- 4,946)
```