### PR TITLE
Update dependencies to remove ahash 0.7.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ include = [
 ]
 
 [dependencies]
-hashbrown = "0.12.0"
-once_cell = "1.10.0"
+hashbrown = "0.14.2"
+once_cell = "1.18.0"
 enum-map = { version = "2", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 arbitrary = { version = "1", optional = true, features = ["derive"] }

--- a/src/trigrams/utils.rs
+++ b/src/trigrams/utils.rs
@@ -143,7 +143,7 @@ mod tests {
             trigram_occurances,
         } = count(&lowercase_text);
         for &(trigram_str, expected_n) in pairs.iter() {
-            let chars: Vec<char> = trigram_str.clone().chars().collect();
+            let chars: Vec<char> = trigram_str.chars().collect();
             let trigram = Trigram(chars[0], chars[1], chars[2]);
             let actual_n = trigram_occurances[&trigram];
             assert_eq!(


### PR DESCRIPTION
The goal of this PR is to tackle the following report from `cargo audit`.

```
Crate:     ahash
Version:   0.7.6
Warning:   yanked
Dependency tree:
ahash 0.7.6
└── hashbrown 0.12.3
    ├── whatlang 0.16.2
```

This PR bumps `hashbrown` to the latest version to fix the issue.