### PR TITLE
Fix trailing commas in supported_languages.csv

### DIFF
--- a/misc/supported_languages.csv
+++ b/misc/supported_languages.csv
@@ -56,8 +56,8 @@ mal,Malayalam,മലയാളം,38
 ori,Oriya,ଓଡ଼ିଆ,36
 mya,Burmese,မြန်မာစာ,33
 nep,Nepali,नेपाली,16
-sin,Sinhalese,සිංහල,16,
-khm,Khmer,ភាសាខ្មែរ,16,
+sin,Sinhalese,සිංහල,16
+khm,Khmer,ភាសាខ្មែរ,16
 tuk,Turkmen,Türkmençe,9
 aka,Akan,Akan,11
 zul,Zulu,IsiZulu,12


### PR DESCRIPTION
In working on an unrelated update, I saw the below from GitHub:

<img width="1468" height="67" alt="Screenshot 2025-12-30 at 11 31 12 AM" src="https://github.com/user-attachments/assets/cc35c686-33b1-4be6-b375-74f1226bb0ec" />

This removes the trailing commas from the `sin` and `khm` entries.